### PR TITLE
linked landing page to documentation

### DIFF
--- a/dist/about-us.html
+++ b/dist/about-us.html
@@ -114,7 +114,7 @@
             <li class="nav-item">
               <a
                 class="nav-link me-lg-3"
-                href="https://github.com/freemocap/freemocap#readme"
+                href="https://freemocap.readthedocs.io"
                 target="_blank"
                 >Documentation
                 <i class="fa fa-external-link" aria-hidden="true"></i></a>
@@ -313,10 +313,6 @@
               <!-- Footer Links-->
               <a href="mailto:info@freemocap.org">Contact</a> •
               <a href="#">About</a>
-              •
-              <a href="https://github.com/freemocap/freemocap/wiki"
-                >Documentation</a
-              >
               •
               <a href="#donate"
                 >Donate <i class="fa fa-heart" aria-hidden="true"></i

--- a/dist/announcements.html
+++ b/dist/announcements.html
@@ -134,7 +134,7 @@
             <li class="nav-item">
               <a
                 class="nav-link me-lg-3"
-                href="https://github.com/freemocap/freemocap#readme"
+                href="https://freemocap.readthedocs.io"
                 target="_blank"
                 >Documentation
                 <i class="fa fa-external-link" aria-hidden="true"></i>
@@ -258,10 +258,6 @@
               <!-- Footer Links-->
               <a href="mailto:info@freemocap.org">Contact</a> •
               <a href="./about-us.html">About</a>
-              •
-              <a href="https://github.com/freemocap/freemocap/wiki"
-                >Documentation</a
-              >
               •
               <a href="./about-us.html#donate"
                 >Donate <i class="fa fa-heart" aria-hidden="true"></i

--- a/dist/ethereum-wallet-page.html
+++ b/dist/ethereum-wallet-page.html
@@ -114,7 +114,7 @@
             <li class="nav-item">
               <a
                 class="nav-link me-lg-3"
-                href="https://github.com/freemocap/freemocap#readme"
+                href="https://freemocap.readthedocs.io"
                 target="_blank"
                 >Documentation
                 <i class="fa fa-external-link" aria-hidden="true"></i></a>
@@ -179,10 +179,6 @@
               <!-- Footer Links-->
               <a href="mailto:info@freemocap.org">Contact</a> •
               <a href="#">About</a>
-              •
-              <a href="https://github.com/freemocap/freemocap/wiki"
-                >Documentation</a
-              >
               •
               <a href="#donate"
                 >Donate <i class="fa fa-heart" aria-hidden="true"></i

--- a/dist/index.html
+++ b/dist/index.html
@@ -121,7 +121,7 @@
             <li class="nav-item">
               <a
                 class="nav-link me-lg-3"
-                href="https://github.com/freemocap/freemocap#readme"
+                href="https://freemocap.readthedocs.io"
                 target="_blank"
                 >Documentation
                 <i class="fa fa-external-link" aria-hidden="true"></i
@@ -429,10 +429,10 @@
           <div class="col-xl-7 col-lg-8 p-5">
             <div class="row">
               <div class="col-md-5">
-                <h2 class="text-white">Install Instructions</h2>
+                <h2 class="text-white">Pre-Alpha Installation Instructions</h2>
                 <br />
                 <p class="text-white">
-                  Learn more at Github.
+                  Learn more from our <a href="https://freemocap.readthedocs.io/" target="_blank">Documentation Site</a>
                   <br />
                   <br />
                   1. Open an Anaconda Prompt (in Windows, or any terminal on
@@ -457,7 +457,7 @@
 
 conda activate freemocap-env
 
-pip install freemocap
+pip install freemocap==0.0.54
 
 ipython
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -570,10 +570,6 @@ fmc.RunMe() #this is where the magic happens.</code></pre>
               <a href="mailto:info@freemocap.org">Contact</a> •
               <a href="./about-us.html">About</a>
               •
-              <a href="https://github.com/freemocap/freemocap/wiki"
-                >Documentation</a
-              >
-              •
               <a href="./about-us.html#donate"
                 >Donate <i class="fa fa-heart" aria-hidden="true"></i
               ></a>

--- a/dist/news.html
+++ b/dist/news.html
@@ -119,7 +119,7 @@
             <li class="nav-item">
               <a
                 class="nav-link me-lg-3"
-                href="https://github.com/freemocap/freemocap#readme"
+                href="https://freemocap.readthedocs.io"
                 target="_blank"
                 >Documentation
                 <i class="fa fa-external-link" aria-hidden="true"></i
@@ -250,10 +250,6 @@
               <!-- Footer Links-->
               <a href="mailto:info@freemocap.org">Contact</a> •
               <a href="./about-us.html">About</a>
-              •
-              <a href="https://github.com/freemocap/freemocap/wiki"
-                >Documentation</a
-              >
               •
               <a href="./about-us.html#donate"
                 >Donate <i class="fa fa-heart" aria-hidden="true"></i


### PR DESCRIPTION
1. The `Documentation` tab now leads to https://freemocap.readthedocs.io
2. I updated the `Installation Instructions` at the bottom of the page, I: 
- (A) specified that it's the pre-alpha 
- (B) added the version number to the freemocap installation 
- (C) created an additional link to our documentation site, just in case