### PR TITLE
Bring /download in-house and redesign the page

### DIFF
--- a/httpdocs/dist/.htaccess
+++ b/httpdocs/dist/.htaccess
@@ -5,7 +5,6 @@ RewriteEngine On
 RewriteBase /
 
 # 1. External redirects (off-site)
-RewriteRule ^download/?$ https://docs.freemocap.org/freemocap/download [NC,L,R=301]
 
 # 2. Internal aliases (old URLs -> current pages)
 RewriteRule ^community/?$ /showcase.html [NC,L,R=301]

--- a/httpdocs/dist/css/main.css
+++ b/httpdocs/dist/css/main.css
@@ -49,6 +49,14 @@ section[id] {
   scroll-margin-top: 75px;
 }
 
+/* Same clearance as section[id] above, for the two anchor-linked download
+   sections, which are div-based (rendered by download.js) rather than
+   actual <section> elements. */
+#app-installer,
+#backend-server {
+  scroll-margin-top: 75px;
+}
+
 .header {
   background-color: var(--bg-tertiary);
   padding: 0.75rem 0;
@@ -1155,6 +1163,15 @@ section[id] {
   line-height: 1.8;
 }
 
+.about-text a {
+  color: var(--accent-teal);
+  text-decoration: none;
+}
+
+.about-text a:hover {
+  text-decoration: underline;
+}
+
 .about-text:last-child {
   margin-bottom: 0;
 }
@@ -1666,49 +1683,21 @@ section[id] {
   max-width: 760px;
 }
 
-/* Download page hero */
-.dl-hero {
-  margin-bottom: 2.5rem;
-}
-
-.dl-title {
-  font-size: 2rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin-bottom: 0.75rem;
-}
-
-.dl-title-accent {
-  color: var(--accent-teal);
-}
-
-.dl-tagline {
-  color: var(--text-secondary);
-  font-size: 0.95rem;
-  line-height: 1.6;
-  max-width: 520px;
-  margin-bottom: 0.75rem;
-}
-
-.dl-tagline a {
-  color: var(--accent-teal);
-  text-decoration: none;
-}
-
-.dl-tagline a:hover {
-  text-decoration: underline;
-}
-
+/* Download page hero. Title/subtitle reuse the shared .page-hero-* classes
+   (same background video/overlay as every other page); these repo links
+   are the one piece of hero content unique to this page. */
 .dl-repo-links {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
+  margin-top: 0.75rem;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.75rem;
 }
 
 .dl-repo-links a {
-  color: var(--text-muted);
+  color: #c2c2c2;
   text-decoration: none;
   transition: color 0.15s ease;
 }
@@ -1718,7 +1707,7 @@ section[id] {
 }
 
 .dl-repo-sep {
-  color: var(--text-muted);
+  color: #c2c2c2;
   opacity: 0.5;
 }
 
@@ -1971,7 +1960,7 @@ details[open] > .dl-toggle .dl-arrow {
 }
 
 .dl-section-block-secondary {
-  margin: 2.5rem 0;
+  margin: 2.5rem 0 1rem;
 }
 
 .dl-section-header {
@@ -2082,6 +2071,21 @@ details[open] > .dl-toggle .dl-arrow {
   letter-spacing: 0.1em;
   color: var(--text-muted);
   margin-bottom: 1rem;
+}
+
+/* "App Installer" / "Backend Server" subheaders inside All platforms &
+   formats, one step down from a .dl-section-title. */
+.dl-all-platforms-subheader {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin: 1rem 0 0.5rem;
+}
+
+.dl-all-platforms-subheader:first-of-type {
+  margin-top: 0.5rem;
 }
 
 .dl-alt-format-label {
@@ -3030,10 +3034,5 @@ details[open] > .dl-toggle .dl-arrow {
   
   .showcase-video-grid {
     grid-template-columns: 1fr;
-  }
-
-  /* Download page */
-  .dl-title {
-    font-size: 1.6rem;
   }
 }

--- a/httpdocs/dist/css/main.css
+++ b/httpdocs/dist/css/main.css
@@ -1657,6 +1657,886 @@ section[id] {
   color: white;
 }
 
+/* Download Page Styles */
+.dl-page {
+  padding: 3rem 0 5rem;
+}
+
+.dl-container {
+  max-width: 760px;
+}
+
+/* Download page hero */
+.dl-hero {
+  margin-bottom: 2.5rem;
+}
+
+.dl-title {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.75rem;
+}
+
+.dl-title-accent {
+  color: var(--accent-teal);
+}
+
+.dl-tagline {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  max-width: 520px;
+  margin-bottom: 0.75rem;
+}
+
+.dl-tagline a {
+  color: var(--accent-teal);
+  text-decoration: none;
+}
+
+.dl-tagline a:hover {
+  text-decoration: underline;
+}
+
+.dl-repo-links {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+}
+
+.dl-repo-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.dl-repo-links a:hover {
+  color: var(--accent-teal);
+}
+
+.dl-repo-sep {
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
+/* Download page detect rows */
+.dl-detect-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.dl-detect-row[hidden] {
+  display: none;
+}
+
+.dl-detected {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.dl-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--accent-teal);
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dl-detected strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.dl-pills-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dl-wrong-detect {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+.dl-pills {
+  display: flex;
+  gap: 0.25rem;
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.dl-pill {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 5px;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  color: var(--text-muted);
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.dl-pill:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.dl-pill.dl-pill-active {
+  color: var(--accent-teal);
+  background: rgba(125, 184, 183, 0.18);
+  font-weight: 600;
+}
+
+/* Download page system help / collapsibles (native <details>) */
+.dl-system-help {
+  margin-bottom: 2rem;
+}
+
+.dl-toggle {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0.5rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  list-style: none;
+  transition: color 0.15s ease;
+}
+
+.dl-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.dl-toggle:hover {
+  color: var(--text-primary);
+}
+
+.dl-arrow {
+  display: inline-block;
+  font-size: 0.6rem;
+  transition: transform 0.2s ease;
+}
+
+details[open] > .dl-toggle .dl-arrow {
+  transform: rotate(90deg);
+}
+
+.dl-help-content {
+  margin-top: 0.75rem;
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+}
+
+.dl-help-section {
+  margin-bottom: 1.25rem;
+}
+
+.dl-help-section:last-child {
+  margin-bottom: 0;
+}
+
+.dl-help-section-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dl-help-icon {
+  font-size: 0.95rem;
+}
+
+.dl-help-section p,
+.dl-help-section li {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.dl-help-section p {
+  margin-bottom: 0.4rem;
+}
+
+.dl-help-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.4rem;
+}
+
+.dl-help-section li {
+  padding: 0.2rem 0 0.2rem 1rem;
+  position: relative;
+}
+
+.dl-help-section li::before {
+  content: '\2192';
+  position: absolute;
+  left: 0;
+  color: var(--accent-teal);
+  font-size: 0.75rem;
+}
+
+.dl-help-section code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.73rem;
+  background: var(--bg-primary);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dl-help-section strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Download page version selector */
+.dl-version-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.dl-version-row[hidden] {
+  display: none;
+}
+
+.dl-version-select {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.dl-version-select:hover {
+  border-color: var(--accent-teal);
+}
+
+/* Download page section blocks */
+.dl-section-block {
+  margin: 3rem 0;
+}
+
+.dl-section-block-secondary {
+  margin: 2.5rem 0;
+}
+
+.dl-section-header {
+  margin-bottom: 1.1rem;
+}
+
+.dl-section-title {
+  font-weight: 700;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.dl-section-title-icon {
+  font-size: 1.1rem;
+}
+
+.dl-section-block-secondary .dl-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.dl-section-subtitle {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.15rem;
+}
+
+.dl-section-subtitle strong {
+  color: var(--accent-teal);
+  font-weight: 600;
+}
+
+.dl-section-block-secondary .dl-section-subtitle strong {
+  color: var(--accent-highlight);
+}
+
+.dl-section-details-content {
+  margin-top: 0.6rem;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.65;
+}
+
+.dl-section-details-content strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.dl-section-details-content code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  background: var(--bg-tertiary);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dl-section-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.dl-alt-format-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  margin: 0.75rem 0 0.5rem;
+}
+
+.dl-section-divider {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin: 0.5rem 0 2.5rem;
+}
+
+/* Download page cards */
+.dl-downloads {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.dl-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  transition: all 0.2s ease;
+  text-decoration: none;
+  color: inherit;
+}
+
+.dl-card:hover {
+  background: #4d4d4d;
+  border-color: var(--accent-teal);
+}
+
+.dl-card-recommended {
+  border-color: rgba(125, 184, 183, 0.4);
+  background: linear-gradient(135deg, var(--bg-tertiary) 0%, rgba(125, 184, 183, 0.08) 100%);
+}
+
+.dl-card-server-rec {
+  border-color: rgba(240, 198, 116, 0.4);
+  background: linear-gradient(135deg, var(--bg-tertiary) 0%, rgba(240, 198, 116, 0.08) 100%);
+}
+
+.dl-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.dl-card-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  color: var(--text-primary);
+}
+
+.dl-card-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.dl-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 700;
+}
+
+.dl-badge-rec {
+  background: rgba(125, 184, 183, 0.18);
+  color: var(--accent-teal);
+}
+
+.dl-badge-server {
+  background: rgba(240, 198, 116, 0.18);
+  color: var(--accent-highlight);
+}
+
+.dl-card-right {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-shrink: 0;
+}
+
+.dl-card-size {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.dl-card-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.5rem 1.1rem;
+  border-radius: 6px;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+.dl-card-btn-primary {
+  background: var(--accent-green);
+  color: white;
+}
+
+.dl-card:hover .dl-card-btn-primary {
+  background: #5a8b8a;
+}
+
+.dl-card-btn-server {
+  background: rgba(240, 198, 116, 0.18);
+  color: var(--accent-highlight);
+}
+
+.dl-card:hover .dl-card-btn-server {
+  background: rgba(240, 198, 116, 0.28);
+}
+
+.dl-card-btn-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.dl-card:hover .dl-card-btn-secondary {
+  border-color: var(--text-muted);
+}
+
+.dl-no-detect {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+/* Download page OS notes */
+.dl-os-note {
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.9rem 1.1rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+}
+
+.dl-os-note-warning {
+  border-color: rgba(240, 198, 116, 0.4);
+}
+
+.dl-os-note-info {
+  border-color: rgba(125, 184, 183, 0.4);
+}
+
+.dl-os-note-icon {
+  font-size: 1rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.dl-os-note-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.25rem;
+}
+
+.dl-os-note-content p {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.dl-os-note-content strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.dl-linked-issues {
+  margin-top: 0.6rem;
+}
+
+.dl-linked-issues-toggle {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  list-style: none;
+  padding: 0.2rem 0;
+}
+
+.dl-linked-issues-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.dl-linked-issues-toggle:hover {
+  color: var(--text-primary);
+}
+
+.dl-linked-issues-count {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-secondary);
+  border-radius: 4px;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.65rem;
+}
+
+.dl-linked-issues-items {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.dl-linked-issue-item {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0.5rem 0.7rem;
+  background: var(--bg-primary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.dl-linked-issue-item:hover {
+  border-color: var(--accent-teal);
+  color: var(--text-primary);
+}
+
+.dl-linked-issue-loading {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  padding: 0.3rem 0;
+}
+
+.dl-issue-type-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-muted);
+}
+
+.dl-issue-status {
+  font-size: 0.75rem;
+}
+
+.dl-issue-status-open {
+  color: var(--accent-green);
+}
+
+.dl-issue-status-closed {
+  color: var(--accent-highlight);
+}
+
+.dl-issue-label-chip {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.dl-linked-issue-arrow {
+  margin-left: auto;
+  opacity: 0.6;
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}
+
+/* Download page code blocks */
+.dl-install-hint {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.65;
+  margin-bottom: 1.5rem;
+}
+
+.dl-install-hint code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  background: var(--bg-tertiary);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dl-code-block {
+  position: relative;
+  background: var(--bg-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.9rem 1rem;
+  margin: 0.6rem 0 0.4rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  line-height: 1.7;
+  color: var(--text-primary);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.dl-prompt {
+  color: var(--accent-teal);
+  user-select: none;
+}
+
+.dl-comment {
+  color: var(--text-muted);
+}
+
+.dl-copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-muted);
+  padding: 0.25rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.dl-copy-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.dl-copy-btn.dl-copy-btn-copied {
+  color: var(--accent-teal);
+  border-color: var(--accent-teal);
+}
+
+/* Download page terminal tip */
+.dl-terminal-tip {
+  margin-top: 0.5rem;
+}
+
+.dl-toggle-terminal-tip {
+  font-size: 0.65rem;
+  opacity: 0.75;
+}
+
+.dl-terminal-tip-content {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.dl-terminal-tip-content p {
+  margin-bottom: 0.4rem;
+}
+
+.dl-terminal-tip-content p:last-child {
+  margin-bottom: 0;
+}
+
+.dl-terminal-tip-content strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.dl-terminal-tip-content code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  background: var(--bg-primary);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* Download page legacy release view */
+.dl-legacy-notice {
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.9rem 1.1rem;
+  margin-bottom: 1.5rem;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+}
+
+.dl-legacy-notice strong {
+  color: var(--text-primary);
+}
+
+.dl-legacy-notice-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.dl-legacy-asset-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dl-legacy-asset {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.dl-legacy-asset:hover {
+  background: #4d4d4d;
+  border-color: var(--accent-teal);
+}
+
+.dl-legacy-asset-name {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.dl-legacy-asset-size {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* Download page footer note */
+.dl-note {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.7;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.dl-note a {
+  color: var(--accent-teal);
+  text-decoration: none;
+}
+
+.dl-note a:hover {
+  text-decoration: underline;
+}
+
+.dl-note code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  background: var(--bg-tertiary);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* Download page focus visibility */
+.dl-pill:focus-visible,
+.dl-toggle:focus-visible,
+.dl-version-select:focus-visible,
+.dl-copy-btn:focus-visible,
+.dl-card:focus-visible,
+.dl-linked-issues-toggle:focus-visible,
+.dl-linked-issue-item:focus-visible {
+  outline: 2px solid var(--accent-teal);
+  outline-offset: 2px;
+}
+
 /* Responsive Design */
 @media (max-width: 1200px) {
   .hero-title {
@@ -1992,6 +2872,29 @@ section[id] {
   .showcase-thumbnail-grid {
     grid-template-columns: repeat(2, 1fr);
   }
+
+  /* Download page */
+  .dl-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .dl-card-right {
+    align-self: stretch;
+    justify-content: space-between;
+  }
+
+  .dl-detect-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dl-legacy-asset {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
 }
 
 @media (max-width: 480px) {
@@ -2061,5 +2964,10 @@ section[id] {
   
   .showcase-video-grid {
     grid-template-columns: 1fr;
+  }
+
+  /* Download page */
+  .dl-title {
+    font-size: 1.6rem;
   }
 }

--- a/httpdocs/dist/css/main.css
+++ b/httpdocs/dist/css/main.css
@@ -1722,13 +1722,24 @@ section[id] {
   opacity: 0.5;
 }
 
+/* Wraps the OS/GPU detect rows now that they sit below the primary download,
+   as a secondary "not right? change it" control rather than a gate in front
+   of the download itself. */
+.dl-detect-zone {
+  margin-bottom: 1.5rem;
+}
+
 /* Download page detect rows */
 .dl-detect-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.dl-detect-row:last-of-type {
+  margin-bottom: 0;
 }
 
 .dl-detect-row[hidden] {
@@ -1759,12 +1770,6 @@ section[id] {
 .dl-detected strong {
   color: var(--text-primary);
   font-weight: 600;
-}
-
-.dl-pills-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
 }
 
 .dl-wrong-detect {
@@ -1810,6 +1815,13 @@ section[id] {
 /* Download page system help / collapsibles (native <details>) */
 .dl-system-help {
   margin-bottom: 2rem;
+}
+
+/* Small consistent gap between stacked collapsibles (e.g. Install
+   instructions -> Install from terminal) so they read as distinct without
+   the full section-level margin between them. */
+.dl-details {
+  margin-top: 0.2rem;
 }
 
 .dl-toggle {
@@ -1949,9 +1961,17 @@ details[open] > .dl-toggle .dl-arrow {
   border-color: var(--accent-teal);
 }
 
-/* Download page section blocks */
+.dl-detect-zone .dl-system-help {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+/* Download page section blocks. #dl-primary leads with plain .dl-section-block
+   (bigger, since it's the first thing after the compact detect rows), while
+   the server section in #dl-secondary adds .dl-section-block-secondary on
+   top to de-emphasize it. */
 .dl-section-block {
-  margin: 3rem 0;
+  margin: 0 0 1rem;
 }
 
 .dl-section-block-secondary {
@@ -1964,14 +1984,14 @@ details[open] > .dl-toggle .dl-arrow {
 
 .dl-section-title {
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 1.4rem;
   display: flex;
   align-items: center;
   gap: 0.6rem;
 }
 
 .dl-section-title-icon {
-  font-size: 1.1rem;
+  font-size: 1.3rem;
 }
 
 .dl-section-block-secondary .dl-section-title {
@@ -1994,6 +2014,20 @@ details[open] > .dl-toggle .dl-arrow {
 
 .dl-section-block-secondary .dl-section-subtitle strong {
   color: var(--accent-highlight);
+}
+
+/* Always-visible replacement for the subtitle + collapsible-details pair,
+   used by sections that pass leadHtml instead of subtitleHtml/detailsLabel. */
+.dl-section-lead {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin-top: 0.5rem;
+}
+
+.dl-section-lead strong {
+  color: var(--accent-teal);
+  font-weight: 600;
 }
 
 .dl-section-details-content {
@@ -2066,9 +2100,28 @@ details[open] > .dl-toggle .dl-arrow {
   border-color: var(--accent-teal);
 }
 
+/* The recommended app-installer card is the page's primary call to action,
+   sized up so it reads as the lede instead of just another list item. */
 .dl-card-recommended {
+  border-width: 2px;
   border-color: rgba(125, 184, 183, 0.4);
   background: linear-gradient(135deg, var(--bg-tertiary) 0%, rgba(125, 184, 183, 0.08) 100%);
+  padding: 1.5rem 1.75rem;
+}
+
+.dl-card-recommended .dl-card-name {
+  font-size: 1.25rem;
+}
+
+.dl-card-recommended .dl-card-meta,
+.dl-card-recommended .dl-card-size {
+  font-size: 0.8rem;
+}
+
+.dl-card-recommended .dl-card-btn-primary {
+  font-size: 0.95rem;
+  padding: 0.85rem 2rem;
+  border-radius: 8px;
 }
 
 .dl-card-server-rec {

--- a/httpdocs/dist/css/main.css
+++ b/httpdocs/dist/css/main.css
@@ -1882,10 +1882,6 @@ details[open] > .dl-toggle .dl-arrow {
   gap: 0.5rem;
 }
 
-.dl-help-icon {
-  font-size: 0.95rem;
-}
-
 .dl-help-section p,
 .dl-help-section li {
   color: var(--text-secondary);
@@ -1982,6 +1978,22 @@ details[open] > .dl-toggle .dl-arrow {
   margin-bottom: 1.1rem;
 }
 
+.dl-section-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+/* Neutralize the standalone version-row's own bottom margin once it's
+   living inline next to the section title instead of stacked in the
+   detect zone, so it centers cleanly against the title instead of
+   sitting low. */
+.dl-section-title-row .dl-version-row {
+  margin-bottom: 0;
+}
+
 .dl-section-title {
   font-weight: 700;
   font-size: 1.4rem;
@@ -2040,6 +2052,18 @@ details[open] > .dl-toggle .dl-arrow {
 .dl-section-details-content strong {
   color: var(--text-primary);
   font-weight: 600;
+}
+
+/* Leading term (".dmg", "AppImage", "macOS", etc.), replacing the old
+   em-dash with teal emphasis plus a little extra space before the rest of
+   the line starts. Scoped per container: in install instructions it needs
+   to outweigh the plain "strong" rule above; in help-section titles the
+   parent sets color directly rather than through a descendant selector, so
+   inheritance alone won't do it either. */
+.dl-section-details-content .dl-install-term,
+.dl-help-section-title .dl-install-term {
+  color: var(--accent-teal);
+  margin-right: 0.35em;
 }
 
 .dl-section-details-content code {
@@ -2247,12 +2271,6 @@ details[open] > .dl-toggle .dl-arrow {
 
 .dl-os-note-info {
   border-color: rgba(125, 184, 183, 0.4);
-}
-
-.dl-os-note-icon {
-  font-size: 1rem;
-  line-height: 1.4;
-  flex-shrink: 0;
 }
 
 .dl-os-note-title {
@@ -2505,11 +2523,6 @@ details[open] > .dl-toggle .dl-arrow {
 
 .dl-legacy-notice strong {
   color: var(--text-primary);
-}
-
-.dl-legacy-notice-icon {
-  font-size: 1rem;
-  flex-shrink: 0;
 }
 
 .dl-legacy-asset-list {

--- a/httpdocs/dist/download.html
+++ b/httpdocs/dist/download.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="description" content="Download FreeMoCap" />
+  <title>Download | The FreeMoCap Project</title>
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/x-icon" href="./assets/favicons/favicon-black.png" />
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  <!-- Icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
+
+  <!-- Custom CSS -->
+  <link rel="stylesheet" href="./css/main.css">
+</head>
+
+<body>
+  <!-- Header (loaded by nav.js) -->
+  <div id="site-header"></div>
+
+  <section class="dl-page">
+    <div class="container dl-container">
+
+      <div class="dl-hero">
+        <h1 class="dl-title">Free<span class="dl-title-accent">MoCap</span></h1>
+        <p class="dl-tagline">
+          Free, open-source markerless motion capture. Record with ordinary cameras and reconstruct full-body 3D movement, no suits, markers, or expensive hardware required.
+        </p>
+        <div class="dl-repo-links">
+          <a href="https://github.com/freemocap/freemocap">GitHub</a>
+          <span class="dl-repo-sep">&middot;</span>
+          <a href="https://github.com/freemocap/freemocap/releases">Release Notes</a>
+          <span class="dl-repo-sep">&middot;</span>
+          <a href="https://github.com/freemocap/freemocap/blob/main/LICENSE">AGPL-3.0</a>
+        </div>
+      </div>
+
+      <div class="dl-detect-row" id="dl-system-detect">
+        <div class="dl-detected">
+          <span class="dl-dot"></span>
+          <span id="dl-detected-text">Detecting your system&hellip;</span>
+        </div>
+        <div class="dl-pills-wrap">
+          <span class="dl-wrong-detect">Not right? Select your system:</span>
+          <div class="dl-pills" id="dl-os-pills" role="group" aria-label="Select your operating system">
+            <button type="button" class="dl-pill" data-os="windows" data-arch="x64">Windows</button>
+            <button type="button" class="dl-pill" data-os="macos" data-arch="arm64">Mac (Apple Silicon)</button>
+            <button type="button" class="dl-pill" data-os="macos" data-arch="x64">Mac (Intel)</button>
+            <button type="button" class="dl-pill" data-os="linux" data-arch="x64">Linux x64</button>
+            <button type="button" class="dl-pill" data-os="linux" data-arch="arm64">Linux ARM64</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="dl-detect-row" id="dl-variant-detect" hidden>
+        <div class="dl-detected">
+          <span class="dl-dot"></span>
+          <span id="dl-variant-detected-text"></span>
+        </div>
+        <div class="dl-pills-wrap">
+          <span class="dl-wrong-detect">Not right? Select a build:</span>
+          <div class="dl-pills" id="dl-variant-pills" role="group" aria-label="Select GPU or CPU build">
+            <button type="button" class="dl-pill" data-variant="cuda">GPU (CUDA)</button>
+            <button type="button" class="dl-pill" data-variant="cpu">CPU only</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="dl-system-help">
+        <details class="dl-details dl-details-help">
+          <summary class="dl-toggle dl-toggle-help"><span class="dl-arrow">&#9654;</span> Not sure what system you have?</summary>
+          <div class="dl-help-content">
+            <div class="dl-help-section">
+              <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F34E;</span> macOS &mdash; Intel or Apple Silicon?</div>
+              <p>Click the Apple menu (&#xF8FF;) in the top-left corner &rarr; <strong>About This Mac</strong>.</p>
+              <ul>
+                <li>If <strong>Chip</strong> says <strong>Apple M1, M2, M3, M4</strong> (or similar) &rarr; you&rsquo;re on <strong>Apple Silicon (ARM64)</strong></li>
+                <li>If <strong>Processor</strong> says <strong>Intel Core i5, i7, i9</strong> etc &rarr; you&rsquo;re on <strong>Intel (x64)</strong></li>
+              </ul>
+              <p>Or run in Terminal: <code>uname -m</code> &mdash; it prints <code>arm64</code> or <code>x86_64</code>.</p>
+            </div>
+            <div class="dl-help-section">
+              <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F427;</span> Linux &mdash; x64 or ARM64?</div>
+              <p>Run in a terminal:</p>
+              <p><code>uname -m</code></p>
+              <ul>
+                <li><code>x86_64</code> &rarr; download the <strong>x64</strong> version</li>
+                <li><code>aarch64</code> &rarr; download the <strong>ARM64</strong> version</li>
+              </ul>
+              <p>Common ARM64 devices: Raspberry Pi 3/4/5, NVIDIA Jetson, some cloud VMs (AWS Graviton, Ampere).</p>
+            </div>
+            <div class="dl-help-section">
+              <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F427;</span> Linux &mdash; AppImage or .deb?</div>
+              <ul>
+                <li><strong>AppImage</strong> &mdash; works on any Linux distro (Ubuntu, Fedora, Arch, etc). Just download and run. No install, no root. Best choice if you&rsquo;re not sure.</li>
+                <li><strong>.deb</strong> &mdash; for Debian-based distros (Ubuntu, Pop!_OS, Linux Mint, Raspberry Pi OS). Integrates with your package manager so it appears in your app launcher and can be cleanly uninstalled.</li>
+              </ul>
+            </div>
+            <div class="dl-help-section">
+              <div class="dl-help-section-title"><span class="dl-help-icon">&#x1FA9F;</span> Windows</div>
+              <p>FreeMoCap provides a single <strong>x64 (64-bit)</strong> build, which works on virtually all modern Windows PCs &mdash; Intel, AMD, and Snapdragon/ARM laptops. If you have a newer Snapdragon X / Windows on ARM machine, the x64 installer still works via Microsoft&rsquo;s built-in emulation layer. There&rsquo;s only one download &mdash; you don&rsquo;t need to choose.</p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <div class="dl-version-row" id="dl-version-row" hidden>
+        <label for="dl-version-select">Version:</label>
+        <select id="dl-version-select" class="dl-version-select"></select>
+      </div>
+
+      <div id="dl-content"></div>
+
+      <div class="dl-note">
+        Part of the <a href="https://freemocap.org">FreeMoCap</a> project.
+        Source code on <a href="https://github.com/freemocap/freemocap">GitHub</a>.
+        Release notes and changelogs on the
+        <a href="https://github.com/freemocap/freemocap/releases">Releases</a> page.
+        Licensed under <code>AGPL-3.0</code>.
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Footer (loaded by nav.js) -->
+  <div id="site-footer"></div>
+
+  <!-- Shared nav loader -->
+  <script src="./js/nav.js"></script>
+  <script src="./js/download.js"></script>
+</body>
+</html>

--- a/httpdocs/dist/download.html
+++ b/httpdocs/dist/download.html
@@ -78,7 +78,7 @@
             <summary class="dl-toggle dl-toggle-help"><span class="dl-arrow">&#9654;</span> Not sure what system you have?</summary>
             <div class="dl-help-content">
               <div class="dl-help-section">
-                <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F34E;</span> macOS &mdash; Intel or Apple Silicon?</div>
+                <div class="dl-help-section-title"><span class="dl-install-term">macOS</span> Intel or Apple Silicon?</div>
                 <p>Click the Apple menu (&#xF8FF;) in the top-left corner &rarr; <strong>About This Mac</strong>.</p>
                 <ul>
                   <li>If <strong>Chip</strong> says <strong>Apple M1, M2, M3, M4</strong> (or similar) &rarr; you&rsquo;re on <strong>Apple Silicon (ARM64)</strong></li>
@@ -87,7 +87,7 @@
                 <p>Or run in Terminal: <code>uname -m</code> &mdash; it prints <code>arm64</code> or <code>x86_64</code>.</p>
               </div>
               <div class="dl-help-section">
-                <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F427;</span> Linux &mdash; x64 or ARM64?</div>
+                <div class="dl-help-section-title"><span class="dl-install-term">Linux</span> x64 or ARM64?</div>
                 <p>Run in a terminal:</p>
                 <p><code>uname -m</code></p>
                 <ul>
@@ -97,14 +97,14 @@
                 <p>Common ARM64 devices: Raspberry Pi 3/4/5, NVIDIA Jetson, some cloud VMs (AWS Graviton, Ampere).</p>
               </div>
               <div class="dl-help-section">
-                <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F427;</span> Linux &mdash; AppImage or .deb?</div>
+                <div class="dl-help-section-title"><span class="dl-install-term">Linux</span> AppImage or .deb?</div>
                 <ul>
                   <li><strong>AppImage</strong> &mdash; works on any Linux distro (Ubuntu, Fedora, Arch, etc). Just download and run. No install, no root. Best choice if you&rsquo;re not sure.</li>
                   <li><strong>.deb</strong> &mdash; for Debian-based distros (Ubuntu, Pop!_OS, Linux Mint, Raspberry Pi OS). Integrates with your package manager so it appears in your app launcher and can be cleanly uninstalled.</li>
                 </ul>
               </div>
               <div class="dl-help-section">
-                <div class="dl-help-section-title"><span class="dl-help-icon">&#x1FA9F;</span> Windows</div>
+                <div class="dl-help-section-title"><span class="dl-install-term">Windows</span></div>
                 <p>FreeMoCap provides a single <strong>x64 (64-bit)</strong> build, which works on virtually all modern Windows PCs &mdash; Intel, AMD, and Snapdragon/ARM laptops. If you have a newer Snapdragon X / Windows on ARM machine, the x64 installer still works via Microsoft&rsquo;s built-in emulation layer. There&rsquo;s only one download &mdash; you don&rsquo;t need to choose.</p>
               </div>
             </div>

--- a/httpdocs/dist/download.html
+++ b/httpdocs/dist/download.html
@@ -43,12 +43,14 @@
         </div>
       </div>
 
-      <div class="dl-detect-row" id="dl-system-detect">
-        <div class="dl-detected">
-          <span class="dl-dot"></span>
-          <span id="dl-detected-text">Detecting your system&hellip;</span>
-        </div>
-        <div class="dl-pills-wrap">
+      <div id="dl-primary"></div>
+
+      <div class="dl-detect-zone">
+        <div class="dl-detect-row" id="dl-system-detect">
+          <div class="dl-detected">
+            <span class="dl-dot"></span>
+            <span id="dl-detected-text">Detecting your system&hellip;</span>
+          </div>
           <span class="dl-wrong-detect">Not right? Select your system:</span>
           <div class="dl-pills" id="dl-os-pills" role="group" aria-label="Select your operating system">
             <button type="button" class="dl-pill" data-os="windows" data-arch="x64">Windows</button>
@@ -58,66 +60,64 @@
             <button type="button" class="dl-pill" data-os="linux" data-arch="arm64">Linux ARM64</button>
           </div>
         </div>
-      </div>
 
-      <div class="dl-detect-row" id="dl-variant-detect" hidden>
-        <div class="dl-detected">
-          <span class="dl-dot"></span>
-          <span id="dl-variant-detected-text"></span>
-        </div>
-        <div class="dl-pills-wrap">
+        <div class="dl-detect-row" id="dl-variant-detect" hidden>
+          <div class="dl-detected">
+            <span class="dl-dot"></span>
+            <span id="dl-variant-detected-text"></span>
+          </div>
           <span class="dl-wrong-detect">Not right? Select a build:</span>
           <div class="dl-pills" id="dl-variant-pills" role="group" aria-label="Select GPU or CPU build">
             <button type="button" class="dl-pill" data-variant="cuda">GPU (CUDA)</button>
             <button type="button" class="dl-pill" data-variant="cpu">CPU only</button>
           </div>
         </div>
+
+        <div class="dl-system-help">
+          <details class="dl-details dl-details-help">
+            <summary class="dl-toggle dl-toggle-help"><span class="dl-arrow">&#9654;</span> Not sure what system you have?</summary>
+            <div class="dl-help-content">
+              <div class="dl-help-section">
+                <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F34E;</span> macOS &mdash; Intel or Apple Silicon?</div>
+                <p>Click the Apple menu (&#xF8FF;) in the top-left corner &rarr; <strong>About This Mac</strong>.</p>
+                <ul>
+                  <li>If <strong>Chip</strong> says <strong>Apple M1, M2, M3, M4</strong> (or similar) &rarr; you&rsquo;re on <strong>Apple Silicon (ARM64)</strong></li>
+                  <li>If <strong>Processor</strong> says <strong>Intel Core i5, i7, i9</strong> etc &rarr; you&rsquo;re on <strong>Intel (x64)</strong></li>
+                </ul>
+                <p>Or run in Terminal: <code>uname -m</code> &mdash; it prints <code>arm64</code> or <code>x86_64</code>.</p>
+              </div>
+              <div class="dl-help-section">
+                <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F427;</span> Linux &mdash; x64 or ARM64?</div>
+                <p>Run in a terminal:</p>
+                <p><code>uname -m</code></p>
+                <ul>
+                  <li><code>x86_64</code> &rarr; download the <strong>x64</strong> version</li>
+                  <li><code>aarch64</code> &rarr; download the <strong>ARM64</strong> version</li>
+                </ul>
+                <p>Common ARM64 devices: Raspberry Pi 3/4/5, NVIDIA Jetson, some cloud VMs (AWS Graviton, Ampere).</p>
+              </div>
+              <div class="dl-help-section">
+                <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F427;</span> Linux &mdash; AppImage or .deb?</div>
+                <ul>
+                  <li><strong>AppImage</strong> &mdash; works on any Linux distro (Ubuntu, Fedora, Arch, etc). Just download and run. No install, no root. Best choice if you&rsquo;re not sure.</li>
+                  <li><strong>.deb</strong> &mdash; for Debian-based distros (Ubuntu, Pop!_OS, Linux Mint, Raspberry Pi OS). Integrates with your package manager so it appears in your app launcher and can be cleanly uninstalled.</li>
+                </ul>
+              </div>
+              <div class="dl-help-section">
+                <div class="dl-help-section-title"><span class="dl-help-icon">&#x1FA9F;</span> Windows</div>
+                <p>FreeMoCap provides a single <strong>x64 (64-bit)</strong> build, which works on virtually all modern Windows PCs &mdash; Intel, AMD, and Snapdragon/ARM laptops. If you have a newer Snapdragon X / Windows on ARM machine, the x64 installer still works via Microsoft&rsquo;s built-in emulation layer. There&rsquo;s only one download &mdash; you don&rsquo;t need to choose.</p>
+              </div>
+            </div>
+          </details>
+        </div>
+  
+        <div class="dl-version-row" id="dl-version-row" hidden>
+          <label for="dl-version-select">Version:</label>
+          <select id="dl-version-select" class="dl-version-select"></select>
+        </div>
       </div>
 
-      <div class="dl-system-help">
-        <details class="dl-details dl-details-help">
-          <summary class="dl-toggle dl-toggle-help"><span class="dl-arrow">&#9654;</span> Not sure what system you have?</summary>
-          <div class="dl-help-content">
-            <div class="dl-help-section">
-              <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F34E;</span> macOS &mdash; Intel or Apple Silicon?</div>
-              <p>Click the Apple menu (&#xF8FF;) in the top-left corner &rarr; <strong>About This Mac</strong>.</p>
-              <ul>
-                <li>If <strong>Chip</strong> says <strong>Apple M1, M2, M3, M4</strong> (or similar) &rarr; you&rsquo;re on <strong>Apple Silicon (ARM64)</strong></li>
-                <li>If <strong>Processor</strong> says <strong>Intel Core i5, i7, i9</strong> etc &rarr; you&rsquo;re on <strong>Intel (x64)</strong></li>
-              </ul>
-              <p>Or run in Terminal: <code>uname -m</code> &mdash; it prints <code>arm64</code> or <code>x86_64</code>.</p>
-            </div>
-            <div class="dl-help-section">
-              <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F427;</span> Linux &mdash; x64 or ARM64?</div>
-              <p>Run in a terminal:</p>
-              <p><code>uname -m</code></p>
-              <ul>
-                <li><code>x86_64</code> &rarr; download the <strong>x64</strong> version</li>
-                <li><code>aarch64</code> &rarr; download the <strong>ARM64</strong> version</li>
-              </ul>
-              <p>Common ARM64 devices: Raspberry Pi 3/4/5, NVIDIA Jetson, some cloud VMs (AWS Graviton, Ampere).</p>
-            </div>
-            <div class="dl-help-section">
-              <div class="dl-help-section-title"><span class="dl-help-icon">&#x1F427;</span> Linux &mdash; AppImage or .deb?</div>
-              <ul>
-                <li><strong>AppImage</strong> &mdash; works on any Linux distro (Ubuntu, Fedora, Arch, etc). Just download and run. No install, no root. Best choice if you&rsquo;re not sure.</li>
-                <li><strong>.deb</strong> &mdash; for Debian-based distros (Ubuntu, Pop!_OS, Linux Mint, Raspberry Pi OS). Integrates with your package manager so it appears in your app launcher and can be cleanly uninstalled.</li>
-              </ul>
-            </div>
-            <div class="dl-help-section">
-              <div class="dl-help-section-title"><span class="dl-help-icon">&#x1FA9F;</span> Windows</div>
-              <p>FreeMoCap provides a single <strong>x64 (64-bit)</strong> build, which works on virtually all modern Windows PCs &mdash; Intel, AMD, and Snapdragon/ARM laptops. If you have a newer Snapdragon X / Windows on ARM machine, the x64 installer still works via Microsoft&rsquo;s built-in emulation layer. There&rsquo;s only one download &mdash; you don&rsquo;t need to choose.</p>
-            </div>
-          </div>
-        </details>
-      </div>
-
-      <div class="dl-version-row" id="dl-version-row" hidden>
-        <label for="dl-version-select">Version:</label>
-        <select id="dl-version-select" class="dl-version-select"></select>
-      </div>
-
-      <div id="dl-content"></div>
+      <div id="dl-secondary"></div>
 
       <div class="dl-note">
         Part of the <a href="https://freemocap.org">FreeMoCap</a> project.

--- a/httpdocs/dist/download.html
+++ b/httpdocs/dist/download.html
@@ -26,22 +26,39 @@
   <!-- Header (loaded by nav.js) -->
   <div id="site-header"></div>
 
+  <section class="page-hero">
+    <video class="page-hero-video" autoplay muted loop playsinline>
+      <source src="./assets/video/home-header-short.mp4" type="video/mp4">
+    </video>
+    <div class="page-hero-overlay"></div>
+    <div class="container">
+      <h1 class="page-hero-title">Download FreeMoCap</h1>
+      <p class="page-hero-subtitle">
+        Free, open-source markerless motion capture.
+      </p>
+      <div class="dl-repo-links">
+        <a href="https://github.com/freemocap/freemocap">GitHub</a>
+        <span class="dl-repo-sep">&middot;</span>
+        <a href="https://github.com/freemocap/freemocap/releases">Release Notes</a>
+        <span class="dl-repo-sep">&middot;</span>
+        <a href="https://github.com/freemocap/freemocap/blob/main/LICENSE">AGPL-3.0</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Intro Section -->
+  <section class="showcase-intro-section">
+    <div class="container">
+      <div class="about-content">
+        <p class="about-text text-center">
+          Record with ordinary cameras and reconstruct full-body 3D movement without suits, markers, or expensive hardware. Download the official FreeMoCap <a href="#app-installer">App Installer</a> for your system, or get the <a href="#backend-server">backend server binary</a> for headless rigs and advanced setups.
+        </p>
+      </div>
+    </div>
+  </section>
+
   <section class="dl-page">
     <div class="container dl-container">
-
-      <div class="dl-hero">
-        <h1 class="dl-title">Free<span class="dl-title-accent">MoCap</span></h1>
-        <p class="dl-tagline">
-          Free, open-source markerless motion capture. Record with ordinary cameras and reconstruct full-body 3D movement, no suits, markers, or expensive hardware required.
-        </p>
-        <div class="dl-repo-links">
-          <a href="https://github.com/freemocap/freemocap">GitHub</a>
-          <span class="dl-repo-sep">&middot;</span>
-          <a href="https://github.com/freemocap/freemocap/releases">Release Notes</a>
-          <span class="dl-repo-sep">&middot;</span>
-          <a href="https://github.com/freemocap/freemocap/blob/main/LICENSE">AGPL-3.0</a>
-        </div>
-      </div>
 
       <div id="dl-primary"></div>
 

--- a/httpdocs/dist/includes/footer.html
+++ b/httpdocs/dist/includes/footer.html
@@ -42,7 +42,7 @@
       <div class="footer-links">
         <div class="footer-column">
           <h3 class="footer-column-title">Get Started</h3>
-          <a href="/download" target="_blank" rel="noopener" class="footer-link">Download</a>
+          <a href="/download" class="footer-link">Download</a>
           <a href="services.html" class="footer-link">Services</a>
           <a href="https://shop.freemocap.org/" target="_blank" rel="noopener" class="footer-link">Shop <i class="bi bi-arrow-up-right"></i></a>
         </div>

--- a/httpdocs/dist/includes/header.html
+++ b/httpdocs/dist/includes/header.html
@@ -8,7 +8,7 @@
 
       <div class="nav-cta-group">
         <a href="services.html" class="cta-button" data-nav="services">Services</a>
-        <a href="/download" target="_blank" rel="noopener" class="cta-button">Download</a>
+        <a href="/download" class="cta-button" data-nav="download">Download</a>
       </div>
 
       <button class="mobile-menu-toggle" aria-label="Toggle menu">
@@ -58,7 +58,7 @@
         <a href="https://shop.freemocap.org/" target="_blank" class="nav-link">Shop <i class="bi bi-arrow-up-right"></i></a>
         <div class="nav-cta-group">
           <a href="services.html" class="cta-button" data-nav="services">Services</a>
-          <a href="/download" target="_blank" rel="noopener" class="cta-button">Download</a>
+          <a href="/download" class="cta-button" data-nav="download">Download</a>
         </div>
       </nav>
     </div>

--- a/httpdocs/dist/index.html
+++ b/httpdocs/dist/index.html
@@ -53,7 +53,7 @@
         </p>
         
         <div class="hero-buttons">
-          <a href="/download" target="_blank" rel="noopener" class="cta-button cta-button-lg">
+          <a href="/download" class="cta-button cta-button-lg">
             <i class="bi bi-download"></i> Download
           </a>
           <a href="https://docs.freemocap.org/documentation/" target="_blank" rel="noopener" class="cta-button cta-button-lg">

--- a/httpdocs/dist/js/download.js
+++ b/httpdocs/dist/js/download.js
@@ -47,11 +47,11 @@
 
   function buildServerDownloads(version) {
     return [
-      { os: 'windows', arch: 'x64', variant: 'cuda', fmt: 'zip', recommended: false, label: 'Server — Windows x64 (CUDA)', file: `freemocap_server_${version}_windows-x64-cuda.zip`, size: '' },
-      { os: 'windows', arch: 'x64', variant: 'cpu', fmt: 'zip', recommended: false, label: 'Server — Windows x64 (CPU)', file: `freemocap_server_${version}_windows-x64-cpu.zip`, size: '' },
-      { os: 'macos', arch: 'arm64', fmt: 'zip', recommended: false, label: 'Server — macOS Apple Silicon', file: `freemocap_server_${version}_macos-arm64-apple-silicon.zip`, size: '' },
-      { os: 'linux', arch: 'x64', variant: 'cuda', fmt: 'zip', recommended: false, label: 'Server — Linux x64 (CUDA)', file: `freemocap_server_${version}_linux-x64-cuda.zip`, size: '' },
-      { os: 'linux', arch: 'x64', variant: 'cpu', fmt: 'zip', recommended: false, label: 'Server — Linux x64 (CPU)', file: `freemocap_server_${version}_linux-x64-cpu.zip`, size: '' },
+      { os: 'windows', arch: 'x64', variant: 'cuda', fmt: 'zip', recommended: false, label: 'Server – Windows x64 (CUDA)', file: `freemocap_server_${version}_windows-x64-cuda.zip`, size: '' },
+      { os: 'windows', arch: 'x64', variant: 'cpu', fmt: 'zip', recommended: false, label: 'Server – Windows x64 (CPU)', file: `freemocap_server_${version}_windows-x64-cpu.zip`, size: '' },
+      { os: 'macos', arch: 'arm64', fmt: 'zip', recommended: false, label: 'Server – macOS (Apple Silicon)', file: `freemocap_server_${version}_macos-arm64-apple-silicon.zip`, size: '' },
+      { os: 'linux', arch: 'x64', variant: 'cuda', fmt: 'zip', recommended: false, label: 'Server – Linux x64 (CUDA)', file: `freemocap_server_${version}_linux-x64-cuda.zip`, size: '' },
+      { os: 'linux', arch: 'x64', variant: 'cpu', fmt: 'zip', recommended: false, label: 'Server – Linux x64 (CPU)', file: `freemocap_server_${version}_linux-x64-cpu.zip`, size: '' },
     ];
   }
 
@@ -130,8 +130,8 @@
     }
     if (os === 'macos') {
       return [
-        { text: '<strong>.dmg</strong> — Open the disk image and drag FreeMoCap into Applications. On first launch, right-click the app and select <strong>Open</strong> to bypass Gatekeeper.' },
-        { text: '<strong>.zip</strong> — Portable version. Unzip and double-click to run without installing.' },
+        { text: '<strong class="dl-install-term">.dmg</strong> Open the disk image and drag FreeMoCap into Applications. On first launch, right-click the app and select <strong>Open</strong> to bypass Gatekeeper.' },
+        { text: '<strong class="dl-install-term">.zip</strong> Portable version. Unzip and double-click to run without installing.' },
       ];
     }
     if (os === 'linux') {
@@ -139,12 +139,12 @@
       const ai = `freemocap_${version}_${label}.AppImage`;
       const deb = `freemocap_${version}_${label}.deb`;
       return [
-        { text: '<strong>AppImage</strong> — Portable, works on any distro. Download, make executable, and run. No root needed.' },
+        { text: '<strong class="dl-install-term">AppImage</strong> Portable, works on any distro. Download, make executable, and run. No root needed.' },
         { codeLines: [
           { type: 'prompt', content: `chmod +x ${ai}`, promptChar: '$' },
           { type: 'prompt', content: `./${ai}`, promptChar: '$' },
         ] },
-        { text: '<strong>.deb</strong> — For Debian, Ubuntu, Pop!_OS, and similar. Installs system-wide with desktop integration.' },
+        { text: '<strong class="dl-install-term">.deb</strong> For Debian, Ubuntu, Pop!_OS, and similar. Installs system-wide with desktop integration.' },
         { codeLines: [{ type: 'prompt', content: `sudo apt install ./${deb}`, promptChar: '$' }] },
       ];
     }
@@ -468,7 +468,6 @@
 
   function renderOsNote(note, idx) {
     const variantClass = note.variant === 'warning' ? 'dl-os-note-warning' : note.variant === 'info' ? 'dl-os-note-info' : '';
-    const icon = note.variant === 'warning' ? '⚠️' : note.variant === 'info' ? 'ℹ️' : '💡';
     const issuesHtml = (note.issues && note.issues.length > 0) ? `
       <details class="dl-linked-issues" data-note-index="${idx}">
         <summary class="dl-linked-issues-toggle"><span class="dl-arrow">&#9654;</span> Linked Issues <span class="dl-linked-issues-count">${note.issues.length}</span></summary>
@@ -478,7 +477,6 @@
 
     return `
       <div class="dl-os-note ${variantClass}">
-        <span class="dl-os-note-icon">${icon}</span>
         <div class="dl-os-note-content">
           <div class="dl-os-note-title">${note.title}</div>
           <p>${note.content}</p>
@@ -586,7 +584,9 @@
     return `
       <div class="${blockClass}">
         <div class="dl-section-header">
-          <div class="dl-section-title">${opts.icon ? `<span class="dl-section-title-icon">${opts.icon}</span> ` : ''}${escapeHtml(opts.title)}</div>
+          <div class="dl-section-title-row">
+            <div class="dl-section-title">${opts.icon ? `<span class="dl-section-title-icon">${opts.icon}</span> ` : ''}${escapeHtml(opts.title)}</div>
+          </div>
           ${headerBodyHtml}
         </div>
         ${notesHtml}
@@ -606,7 +606,6 @@
     return `
       <details class="dl-details">
         <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> Install from terminal</summary>
-        <div class="dl-section-label" style="margin-top:8px">One-liner install from terminal</div>
         <p class="dl-install-hint">Download and run directly using <code>curl</code>.</p>
         ${blocksHtml}
         ${renderTerminalTip(os)}
@@ -617,7 +616,6 @@
   function renderAllPlatformsSection(otherApp, otherServer, version, defaultOpen) {
     if (otherApp.length === 0 && otherServer.length === 0) return '';
     const appHtml = otherApp.length > 0 ? `
-      <div class="dl-section-label" style="margin-top:8px">App Installer — other platforms</div>
       <div class="dl-downloads">${otherApp.map(d => renderCard(d, 'secondary', version)).join('')}</div>
     ` : '';
     const serverHtml = otherServer.length > 0 ? `
@@ -644,7 +642,6 @@
 
     return `
       <div class="dl-legacy-notice">
-        <span class="dl-legacy-notice-icon">📦</span>
         <div>This release (<strong>${escapeHtml(tagName)}</strong>) predates our smart download page. Here are all available files — pick the one that matches your system.</div>
       </div>
       <div class="dl-legacy-asset-list">${itemsHtml}</div>
@@ -780,17 +777,29 @@
       terminalInstallHtml: !isUnavailablePlatform ? renderTerminalInstallSection(state.os, state.arch, variantForInstructions, version) : '',
     });
 
+    // Grab the version row before the innerHTML wipe below, since by the
+    // second render it lives inside primaryContainer (moved there at the
+    // end of the previous call) and would otherwise be destroyed along
+    // with the rest of the old markup before we could reattach it.
+    const versionRow = document.getElementById('dl-version-row');
+
     primaryContainer.innerHTML = primaryHtml;
     wireLinkedIssues(primaryContainer, activeNotes);
     wireCopyButtons(primaryContainer);
+
+    // Move the (already-wired) version row into place next to the title.
+    // A plain move, not a rebuild, so its select element and change
+    // listener survive the reattachment untouched.
+    const titleRow = primaryContainer.querySelector('.dl-section-title-row');
+    if (titleRow && versionRow) titleRow.appendChild(versionRow);
 
     let secondaryHtml = '';
     if (!isUnavailablePlatform) {
       secondaryHtml += '<hr class="dl-section-divider">';
       secondaryHtml += renderDownloadSection({
-        icon: '⚡',
+        icon: '',
         title: 'FreeMoCap Backend Server',
-        subtitleHtml: '<strong>Advanced</strong> — headless machines, remote capture rigs, API use',
+        subtitleHtml: '<strong>Advanced.</strong> Headless machines, remote capture rigs, API use.',
         detailsLabel: 'When do I need this?',
         detailsContentHtml: 'Just the camera backend server binary, no GUI. Useful for headless capture rigs, remote systems you connect to over a network, or building a custom client against the FreeMoCap API. <strong>You don’t need this if you downloaded the App Installer above.</strong>',
         recommended: recServer,

--- a/httpdocs/dist/js/download.js
+++ b/httpdocs/dist/js/download.js
@@ -557,7 +557,7 @@
       : opts.recommended.map(d => renderCard(d, cardVariant, opts.version)).join('');
 
     const alternatesHtml = (opts.alternates && opts.alternates.length > 0) ? `
-      <div class="dl-alt-format-label">Also available for your system</div>
+      <div class="dl-alt-format-label">Also available for your system:</div>
       <div class="dl-downloads">${opts.alternates.map(d => renderCard(d, 'secondary', opts.version)).join('')}</div>
     ` : '';
 
@@ -573,20 +573,27 @@
       `;
     }
 
+    const headerBodyHtml = opts.leadHtml
+      ? `<p class="dl-section-lead">${opts.leadHtml}</p>`
+      : `
+        <div class="dl-section-subtitle">${opts.subtitleHtml}</div>
+        <details class="dl-details">
+          <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> ${escapeHtml(opts.detailsLabel)}</summary>
+          <div class="dl-section-details-content">${opts.detailsContentHtml}</div>
+        </details>
+      `;
+
     return `
       <div class="${blockClass}">
         <div class="dl-section-header">
-          <div class="dl-section-title"><span class="dl-section-title-icon">${opts.icon}</span> ${escapeHtml(opts.title)}</div>
-          <div class="dl-section-subtitle">${opts.subtitleHtml}</div>
-          <details class="dl-details">
-            <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> ${escapeHtml(opts.detailsLabel)}</summary>
-            <div class="dl-section-details-content">${opts.detailsContentHtml}</div>
-          </details>
+          <div class="dl-section-title">${opts.icon ? `<span class="dl-section-title-icon">${opts.icon}</span> ` : ''}${escapeHtml(opts.title)}</div>
+          ${headerBodyHtml}
         </div>
         ${notesHtml}
         <div class="dl-downloads">${downloadsHtml}</div>
         ${alternatesHtml}
         ${instructionsHtml}
+        ${opts.terminalInstallHtml || ''}
       </div>
     `;
   }
@@ -708,13 +715,15 @@
   }
 
   function renderMainContent() {
-    const container = document.getElementById('dl-content');
+    const primaryContainer = document.getElementById('dl-primary');
+    const secondaryContainer = document.getElementById('dl-secondary');
     const version = stripVersionPrefix(state.tag);
     const selectedRelease = state.releases.find(r => r.tag_name === state.tag);
     const isLegacy = selectedRelease ? !matchesExpectedPattern(selectedRelease.assets, version) : false;
 
     if (isLegacy && selectedRelease) {
-      container.innerHTML = renderLegacyView(selectedRelease.assets, selectedRelease.tag_name);
+      primaryContainer.innerHTML = renderLegacyView(selectedRelease.assets, selectedRelease.tag_name);
+      secondaryContainer.innerHTML = '';
       return;
     }
 
@@ -754,12 +763,10 @@
     const noDetect = state.os === 'unknown';
     const terminalTipOs = (osForInstructions && osForInstructions !== 'windows') ? osForInstructions : undefined;
 
-    let html = renderDownloadSection({
-      icon: '💀📸',
-      title: 'FreeMoCap App Installer',
-      subtitleHtml: '<strong>Recommended</strong> — this is what most people want',
-      detailsLabel: "What's included?",
-      detailsContentHtml: 'Desktop application with camera preview, recording controls, and settings. The backend server is already bundled inside — you don’t need to download it separately.',
+    const primaryHtml = renderDownloadSection({
+      icon: '',
+      title: 'App Installer',
+      leadHtml: '<strong>Recommended.</strong> Desktop application with camera preview, recording controls, and settings. The backend server is already bundled inside, meaning you don’t need to download it separately.',
       recommended: recApp,
       alternates: altApp,
       installInstructions: appInstructions,
@@ -770,12 +777,17 @@
       terminalTipOs,
       notes: activeNotes,
       notesStartIndex: 0,
+      terminalInstallHtml: !isUnavailablePlatform ? renderTerminalInstallSection(state.os, state.arch, variantForInstructions, version) : '',
     });
 
+    primaryContainer.innerHTML = primaryHtml;
+    wireLinkedIssues(primaryContainer, activeNotes);
+    wireCopyButtons(primaryContainer);
+
+    let secondaryHtml = '';
     if (!isUnavailablePlatform) {
-      html += renderTerminalInstallSection(state.os, state.arch, variantForInstructions, version);
-      html += '<hr class="dl-section-divider">';
-      html += renderDownloadSection({
+      secondaryHtml += '<hr class="dl-section-divider">';
+      secondaryHtml += renderDownloadSection({
         icon: '⚡',
         title: 'FreeMoCap Backend Server',
         subtitleHtml: '<strong>Advanced</strong> — headless machines, remote capture rigs, API use',
@@ -793,11 +805,10 @@
       });
     }
 
-    html += renderAllPlatformsSection(otherApp, otherServer, version, noDetect);
+    secondaryHtml += renderAllPlatformsSection(otherApp, otherServer, version, noDetect);
 
-    container.innerHTML = html;
-    wireLinkedIssues(container, activeNotes);
-    wireCopyButtons(container);
+    secondaryContainer.innerHTML = secondaryHtml;
+    wireCopyButtons(secondaryContainer);
   }
 
   function render() {

--- a/httpdocs/dist/js/download.js
+++ b/httpdocs/dist/js/download.js
@@ -1,0 +1,877 @@
+/**
+ * Download page logic for freemocap.org/download.
+ *
+ * Ported from the FreeMoCap docs site's React download page
+ * (freemocap/freemocap, freemocap-docs/src/components/download/). Detects
+ * the visitor's OS/GPU, fetches live release data from the GitHub API, and
+ * renders OS-specific installer/server downloads with install instructions.
+ * No build step - single classic script, matching nav.js's convention.
+ */
+(async function initDownloadPage() {
+  // ── data ─────────────────────────────────────────────────
+  const REPO = 'freemocap/freemocap';
+  const DEFAULT_VERSION = '2.0.0-alpha.6';
+  const R2_PUBLIC_URL = 'https://pub-0a275a10417e425c94e48de393793129.r2.dev';
+
+  function getReleaseBaseUrl(version) {
+    return `https://github.com/${REPO}/releases/download/v${version}`;
+  }
+
+  function getR2BaseUrl(version) {
+    return `${R2_PUBLIC_URL}/releases/v${version}`;
+  }
+
+  // Only the Linux CUDA build exceeds GitHub's 2GB per-asset limit, so it
+  // alone is hosted on R2. Mirrors build-installers-pyinstaller.yml.
+  function isR2Hosted(os, variant) {
+    return os === 'linux' && variant === 'cuda';
+  }
+
+  function downloadUrl(file, os, version, variant) {
+    const base = isR2Hosted(os, variant) ? getR2BaseUrl(version) : getReleaseBaseUrl(version);
+    return `${base}/${file}`;
+  }
+
+  function buildAppDownloads(version) {
+    return [
+      { os: 'windows', arch: 'x64', variant: 'cuda', fmt: 'exe', recommended: true, label: 'Windows Installer (GPU · CUDA)', file: `freemocap_${version}_windows-x64-cuda.exe`, size: '' },
+      { os: 'windows', arch: 'x64', variant: 'cpu', fmt: 'exe', recommended: true, label: 'Windows Installer (CPU-only)', file: `freemocap_${version}_windows-x64-cpu.exe`, size: '' },
+      { os: 'macos', arch: 'arm64', fmt: 'dmg', recommended: true, label: 'macOS Installer (Apple Silicon)', file: `freemocap_${version}_macos-arm64-apple-silicon.dmg`, size: '' },
+      { os: 'macos', arch: 'arm64', fmt: 'zip', recommended: false, label: 'macOS Portable (Apple Silicon)', file: `freemocap_${version}_macos-arm64-apple-silicon.zip`, size: '' },
+      { os: 'linux', arch: 'x64', variant: 'cuda', fmt: 'AppImage', recommended: true, label: 'Linux AppImage (GPU · CUDA)', file: `freemocap_${version}_linux-x64-cuda.AppImage`, size: '' },
+      { os: 'linux', arch: 'x64', variant: 'cuda', fmt: 'deb', recommended: false, label: 'Linux .deb (GPU · CUDA)', file: `freemocap_${version}_linux-x64-cuda.deb`, size: '' },
+      { os: 'linux', arch: 'x64', variant: 'cpu', fmt: 'AppImage', recommended: true, label: 'Linux AppImage (CPU-only)', file: `freemocap_${version}_linux-x64-cpu.AppImage`, size: '' },
+      { os: 'linux', arch: 'x64', variant: 'cpu', fmt: 'deb', recommended: false, label: 'Linux .deb (CPU-only)', file: `freemocap_${version}_linux-x64-cpu.deb`, size: '' },
+    ];
+  }
+
+  function buildServerDownloads(version) {
+    return [
+      { os: 'windows', arch: 'x64', variant: 'cuda', fmt: 'zip', recommended: false, label: 'Server — Windows x64 (CUDA)', file: `freemocap_server_${version}_windows-x64-cuda.zip`, size: '' },
+      { os: 'windows', arch: 'x64', variant: 'cpu', fmt: 'zip', recommended: false, label: 'Server — Windows x64 (CPU)', file: `freemocap_server_${version}_windows-x64-cpu.zip`, size: '' },
+      { os: 'macos', arch: 'arm64', fmt: 'zip', recommended: false, label: 'Server — macOS Apple Silicon', file: `freemocap_server_${version}_macos-arm64-apple-silicon.zip`, size: '' },
+      { os: 'linux', arch: 'x64', variant: 'cuda', fmt: 'zip', recommended: false, label: 'Server — Linux x64 (CUDA)', file: `freemocap_server_${version}_linux-x64-cuda.zip`, size: '' },
+      { os: 'linux', arch: 'x64', variant: 'cpu', fmt: 'zip', recommended: false, label: 'Server — Linux x64 (CPU)', file: `freemocap_server_${version}_linux-x64-cpu.zip`, size: '' },
+    ];
+  }
+
+  function formatBytes(bytes) {
+    const mb = bytes / (1024 * 1024);
+    return `~${Math.round(mb)} MB`;
+  }
+
+  function enrichDownloadsWithAssets(downloads, assets) {
+    const assetMap = new Map(assets.map(a => [a.name, a]));
+    return downloads.map(d => {
+      const asset = assetMap.get(d.file);
+      return asset ? Object.assign({}, d, { size: formatBytes(asset.size) }) : d;
+    });
+  }
+
+  function enrichDownloadsWithR2Sizes(downloads, version, sizeByUrl) {
+    return downloads.map(d => {
+      if (!isR2Hosted(d.os, d.variant)) return d;
+      const size = sizeByUrl[downloadUrl(d.file, d.os, version, d.variant)];
+      return size != null ? Object.assign({}, d, { size: formatBytes(size) }) : d;
+    });
+  }
+
+  function matchesExpectedPattern(assets, version) {
+    const expectedFiles = [...buildAppDownloads(version).map(d => d.file), ...buildServerDownloads(version).map(d => d.file)];
+    const assetNames = new Set(assets.map(a => a.name));
+    return expectedFiles.filter(f => assetNames.has(f)).length >= 3;
+  }
+
+  function hasVariant(os, arch) {
+    return (os === 'windows' || os === 'linux') && arch === 'x64';
+  }
+
+  function fileLabel(os, arch, variant) {
+    if (os === 'macos') return 'macos-arm64-apple-silicon';
+    const base = os === 'linux' ? 'linux-x64' : 'windows-x64';
+    return variant ? `${base}-${variant}` : base;
+  }
+
+  function formatMeta(d) {
+    const parts = [d.fmt.toUpperCase()];
+    if (d.os !== 'windows') parts.push(d.arch === 'arm64' ? 'ARM64' : 'x64');
+    return parts.join(' · ');
+  }
+
+  const OS_LABELS = { windows: 'Windows x64', macos: 'macOS', linux: 'Linux', unknown: 'Unknown OS' };
+
+  function archLabel(arch) {
+    return arch === 'arm64' ? 'ARM64 / Apple Silicon' : 'x64 / Intel';
+  }
+
+  function stripVersionPrefix(tag) {
+    return tag.replace(/^v/, '');
+  }
+
+  const OS_NOTES = [
+    {
+      os: 'macos', arch: 'x64', variant: 'warning',
+      title: 'Intel Mac builds aren’t available yet',
+      content: 'FreeMoCap’s pose-tracking backend (onnxruntime, via skellytracker) doesn’t currently publish a macOS x86_64 wheel, so we can’t build for Intel Macs yet. If you’re on Apple Silicon, select that option above instead.',
+      issues: [{ label: 'Add macOS Intel (x86_64) installer build', url: 'https://github.com/freemocap/freemocap/issues/823' }],
+    },
+    {
+      os: 'linux', arch: 'arm64', variant: 'warning',
+      title: 'Linux ARM64 builds aren’t available',
+      content: 'We can’t build a Linux ARM64 release (e.g. for Raspberry Pi) yet: mediapipe — a core dependency of the pose-tracking backend — ships no linux-aarch64 wheel, so the build is unsatisfiable on that platform. It’ll stay unavailable until mediapipe publishes ARM64 Linux wheels.',
+      issues: [{ label: 'Add Linux ARM64 installer build', url: 'https://github.com/freemocap/freemocap/issues/822' }],
+    },
+  ];
+
+  // ── install instructions ────────────────────────────────
+  function getAppInstallInstructions(os, arch, variant, version) {
+    if (os === 'windows') {
+      return [{ text: 'Download and run the <code>.exe</code> installer. If Windows SmartScreen appears, click <strong>"More info"</strong> → <strong>"Run anyway"</strong>.' }];
+    }
+    if (os === 'macos') {
+      return [
+        { text: '<strong>.dmg</strong> — Open the disk image and drag FreeMoCap into Applications. On first launch, right-click the app and select <strong>Open</strong> to bypass Gatekeeper.' },
+        { text: '<strong>.zip</strong> — Portable version. Unzip and double-click to run without installing.' },
+      ];
+    }
+    if (os === 'linux') {
+      const label = fileLabel(os, arch, variant);
+      const ai = `freemocap_${version}_${label}.AppImage`;
+      const deb = `freemocap_${version}_${label}.deb`;
+      return [
+        { text: '<strong>AppImage</strong> — Portable, works on any distro. Download, make executable, and run. No root needed.' },
+        { codeLines: [
+          { type: 'prompt', content: `chmod +x ${ai}`, promptChar: '$' },
+          { type: 'prompt', content: `./${ai}`, promptChar: '$' },
+        ] },
+        { text: '<strong>.deb</strong> — For Debian, Ubuntu, Pop!_OS, and similar. Installs system-wide with desktop integration.' },
+        { codeLines: [{ type: 'prompt', content: `sudo apt install ./${deb}`, promptChar: '$' }] },
+      ];
+    }
+    return [];
+  }
+
+  function getServerInstallInstructions(os, arch, variant, version) {
+    const label = fileLabel(os, arch, variant);
+    const zip = `freemocap_server_${version}_${label}.zip`;
+    const bin = os === 'windows' ? 'freemocap_server.exe' : 'freemocap_server';
+
+    if (os === 'windows') {
+      return [
+        { text: 'Download the <code>.zip</code>, extract it, then run the server from inside the extracted folder — it needs its bundled support files alongside it. Starts a local API on port <code>53117</code>.' },
+        { codeLines: [
+          { type: 'prompt', content: `Expand-Archive ${zip} -DestinationPath freemocap_server`, promptChar: '>' },
+          { type: 'prompt', content: 'cd freemocap_server', promptChar: '>' },
+          { type: 'prompt', content: `.\\${bin}`, promptChar: '>' },
+        ] },
+      ];
+    }
+    if (os === 'macos') {
+      return [
+        { text: 'Download the <code>.zip</code>, extract it, then make the binary executable and run it from Terminal — it needs its bundled support files alongside it.' },
+        { codeLines: [
+          { type: 'prompt', content: `unzip ${zip} -d freemocap_server`, promptChar: '$' },
+          { type: 'prompt', content: 'cd freemocap_server', promptChar: '$' },
+          { type: 'prompt', content: `chmod +x ${bin}`, promptChar: '$' },
+          { type: 'prompt', content: `xattr -cr ${bin}`, promptChar: '$' },
+          { type: 'prompt', content: `./${bin}`, promptChar: '$' },
+        ] },
+        { text: 'The <code>xattr</code> command clears the macOS quarantine flag so Gatekeeper won’t block it.' },
+      ];
+    }
+    if (os === 'linux') {
+      return [
+        { text: 'Download the <code>.zip</code>, extract it, then make the binary executable and run it — it needs its bundled support files alongside it. Ideal for headless rigs and remote capture machines.' },
+        { codeLines: [
+          { type: 'prompt', content: `unzip ${zip} -d freemocap_server`, promptChar: '$' },
+          { type: 'prompt', content: 'cd freemocap_server', promptChar: '$' },
+          { type: 'prompt', content: `chmod +x ${bin}`, promptChar: '$' },
+          { type: 'prompt', content: `./${bin}`, promptChar: '$' },
+          { type: 'text', content: '' },
+          { type: 'comment', content: '# Or run in background (survives terminal close)' },
+          { type: 'prompt', content: `nohup ./${bin} &`, promptChar: '$' },
+        ] },
+      ];
+    }
+    return [];
+  }
+
+  function getTerminalInstallBlocks(os, arch, variant, version) {
+    if (os !== 'linux' && os !== 'macos') return [];
+    const label = fileLabel(os, arch, variant);
+    const srvZip = `freemocap_server_${version}_${label}.zip`;
+    const blocks = [];
+
+    if (os === 'linux') {
+      const ai = `freemocap_${version}_${label}.AppImage`;
+      const deb = `freemocap_${version}_${label}.deb`;
+      blocks.push({ codeLines: [
+        { type: 'comment', content: '# App Installer — AppImage (any distro, no root)' },
+        { type: 'prompt', content: `curl -fSL -o freemocap.AppImage "${downloadUrl(ai, os, version, variant)}"`, promptChar: '$' },
+        { type: 'prompt', content: 'chmod +x freemocap.AppImage', promptChar: '$' },
+        { type: 'prompt', content: './freemocap.AppImage', promptChar: '$' },
+      ] });
+      blocks.push({ codeLines: [
+        { type: 'comment', content: '# App Installer — .deb (Debian/Ubuntu)' },
+        { type: 'prompt', content: `curl -fSL -o freemocap.deb "${downloadUrl(deb, os, version, variant)}"`, promptChar: '$' },
+        { type: 'prompt', content: 'sudo apt install ./freemocap.deb', promptChar: '$' },
+      ] });
+      blocks.push({ codeLines: [
+        { type: 'comment', content: '# Backend Server (headless / remote capture)' },
+        { type: 'prompt', content: `curl -fSL -o freemocap_server.zip "${downloadUrl(srvZip, os, version, variant)}"`, promptChar: '$' },
+        { type: 'prompt', content: 'unzip freemocap_server.zip -d freemocap_server && cd freemocap_server', promptChar: '$' },
+        { type: 'prompt', content: 'chmod +x freemocap_server', promptChar: '$' },
+        { type: 'prompt', content: './freemocap_server', promptChar: '$' },
+      ] });
+    }
+
+    if (os === 'macos') {
+      const dmg = `freemocap_${version}_${label}.dmg`;
+      blocks.push({ codeLines: [
+        { type: 'comment', content: '# App Installer' },
+        { type: 'prompt', content: `curl -fSL -o freemocap.dmg "${downloadUrl(dmg, os, version, variant)}"`, promptChar: '$' },
+        { type: 'prompt', content: 'open freemocap.dmg', promptChar: '$' },
+      ] });
+      blocks.push({ codeLines: [
+        { type: 'comment', content: '# Backend Server' },
+        { type: 'prompt', content: `curl -fSL -o freemocap_server.zip "${downloadUrl(srvZip, os, version, variant)}"`, promptChar: '$' },
+        { type: 'prompt', content: 'unzip freemocap_server.zip -d freemocap_server && cd freemocap_server', promptChar: '$' },
+        { type: 'prompt', content: 'chmod +x freemocap_server && xattr -cr freemocap_server', promptChar: '$' },
+        { type: 'prompt', content: './freemocap_server', promptChar: '$' },
+      ] });
+    }
+
+    return blocks;
+  }
+
+  function getTerminalTipContent(os) {
+    if (os === 'windows') {
+      return { openHow: 'Press <code>Win + X</code> then choose <strong>Terminal</strong>, or search for <strong>"PowerShell"</strong> in the Start menu.', promptChar: '<code>&gt;</code>' };
+    }
+    if (os === 'macos') {
+      return { openHow: 'Open <strong>Terminal</strong> from <strong>Applications → Utilities → Terminal</strong>, or press <code>Cmd + Space</code> and type <strong>"Terminal"</strong>.', promptChar: '<code>$</code>' };
+    }
+    return { openHow: 'Open your terminal emulator. On most desktops, press <code>Ctrl + Alt + T</code> or find <strong>"Terminal"</strong> in your application launcher.', promptChar: '<code>$</code>' };
+  }
+
+  // ── detection ────────────────────────────────────────────
+  function detectSystem() {
+    const ua = navigator.userAgent.toLowerCase();
+    const platform = (navigator.platform || '').toLowerCase();
+
+    let os = 'unknown';
+    if (ua.includes('win')) os = 'windows';
+    else if (ua.includes('mac')) os = 'macos';
+    else if (ua.includes('linux') || ua.includes('x11')) os = 'linux';
+
+    let arch = 'x64';
+    if (ua.includes('arm64') || ua.includes('aarch64') || platform.includes('arm')) {
+      arch = 'arm64';
+    }
+
+    if (os === 'macos') {
+      try {
+        const c = document.createElement('canvas');
+        const gl = c.getContext('webgl') || c.getContext('experimental-webgl');
+        if (gl) {
+          const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+          if (debugInfo) {
+            const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+            if (/Apple\s+(M[1-9]|GPU)/.test(renderer)) arch = 'arm64';
+          }
+        }
+      } catch (_) { /* ignore */ }
+    }
+
+    return { os, arch };
+  }
+
+  function refineMacArch(onRefined) {
+    if (navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {
+      navigator.userAgentData.getHighEntropyValues(['architecture'])
+        .then(v => { if (v.architecture === 'arm') onRefined('arm64'); })
+        .catch(() => {});
+    }
+  }
+
+  function detectGpu() {
+    try {
+      const c = document.createElement('canvas');
+      const gl = c.getContext('webgl') || c.getContext('experimental-webgl');
+      if (gl) {
+        const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+        if (debugInfo) {
+          const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+          if (typeof renderer === 'string' && /NVIDIA/i.test(renderer)) {
+            return { variant: 'cuda', detected: true };
+          }
+        }
+      }
+    } catch (_) { /* ignore */ }
+    return { variant: 'cpu', detected: false };
+  }
+
+  // ── fetch + cache ────────────────────────────────────────
+  function readSessionCache(key, ttl) {
+    try {
+      const raw = sessionStorage.getItem(key);
+      if (!raw) return null;
+      const entry = JSON.parse(raw);
+      if (Date.now() - entry.timestamp > ttl) {
+        sessionStorage.removeItem(key);
+        return null;
+      }
+      return entry.data;
+    } catch (_) { return null; }
+  }
+
+  function writeSessionCache(key, data) {
+    try {
+      sessionStorage.setItem(key, JSON.stringify({ timestamp: Date.now(), data }));
+    } catch (_) { /* full or unavailable */ }
+  }
+
+  const RELEASES_CACHE_KEY = 'freemocap-releases';
+  const RELEASES_CACHE_TTL_MS = 10 * 60 * 1000;
+
+  async function fetchReleases() {
+    const cached = readSessionCache(RELEASES_CACHE_KEY, RELEASES_CACHE_TTL_MS);
+    if (cached) return cached;
+    const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`, {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+    const data = await res.json();
+    writeSessionCache(RELEASES_CACHE_KEY, data);
+    return data;
+  }
+
+  const R2_SIZES_CACHE_KEY = 'freemocap-r2-sizes';
+  const R2_SIZES_CACHE_TTL_MS = 60 * 60 * 1000;
+
+  async function fetchR2Sizes(urls) {
+    if (urls.length === 0) return {};
+    const cached = readSessionCache(R2_SIZES_CACHE_KEY, R2_SIZES_CACHE_TTL_MS) || {};
+    const missing = urls.filter(u => cached[u] == null);
+    if (missing.length === 0) return cached;
+
+    const results = await Promise.all(missing.map(async url => {
+      try {
+        const res = await fetch(url, { method: 'HEAD' });
+        const len = res.headers.get('content-length');
+        return len ? [url, Number(len)] : null;
+      } catch (_) { return null; }
+    }));
+
+    const merged = Object.assign({}, cached);
+    results.forEach(r => { if (r) merged[r[0]] = r[1]; });
+    writeSessionCache(R2_SIZES_CACHE_KEY, merged);
+    return merged;
+  }
+
+  const ISSUE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+  function parseIssueUrl(url) {
+    try {
+      const u = new URL(url);
+      const match = u.pathname.match(/^\/([^/]+\/[^/]+)\/(?:issues|pull)\/(\d+)/);
+      if (!match) return null;
+      return { repo: match[1], number: Number.parseInt(match[2], 10) };
+    } catch (_) { return null; }
+  }
+
+  async function fetchIssueMetadata(url) {
+    const cacheKey = `sk-linked-${url}`;
+    try {
+      const raw = localStorage.getItem(cacheKey);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Date.now() - parsed.timestamp < ISSUE_CACHE_TTL_MS) return parsed.data;
+      }
+    } catch (_) { /* ignore */ }
+
+    const parsedUrl = parseIssueUrl(url);
+    if (!parsedUrl) return null;
+
+    try {
+      const resp = await fetch(`https://api.github.com/repos/${parsedUrl.repo}/issues/${parsedUrl.number}`, {
+        headers: { Accept: 'application/vnd.github.v3+json' },
+      });
+      if (!resp.ok) return null;
+      const raw = await resp.json();
+      const labels = (raw.labels || []).map(l => ({ name: l.name, color: l.color })).filter(l => l.name !== 'roadmap');
+      const data = { status: raw.state === 'open' ? 'open' : 'closed', type: raw.pull_request ? 'pr' : 'issue', labels };
+      try { localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data })); } catch (_) { /* full or unavailable */ }
+      return data;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ── render helpers ───────────────────────────────────────
+  function escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = String(str);
+    return div.innerHTML;
+  }
+
+  function renderCard(d, variant, version) {
+    const cardClasses = ['dl-card'];
+    if (variant === 'recommended') cardClasses.push('dl-card-recommended');
+    if (variant === 'server-rec') cardClasses.push('dl-card-server-rec');
+
+    const btnClass = variant === 'recommended' ? 'dl-card-btn-primary' : variant === 'server-rec' ? 'dl-card-btn-server' : 'dl-card-btn-secondary';
+    const badgeClass = variant === 'recommended' ? 'dl-badge-rec' : variant === 'server-rec' ? 'dl-badge-server' : null;
+    const badgeText = variant === 'recommended' ? 'recommended' : variant === 'server-rec' ? 'your system' : null;
+    const url = downloadUrl(d.file, d.os, version, d.variant);
+
+    return `
+      <a href="${escapeHtml(url)}" class="${cardClasses.join(' ')}">
+        <div class="dl-card-info">
+          <div class="dl-card-name">
+            ${escapeHtml(d.label)}
+            ${badgeClass ? `<span class="dl-badge ${badgeClass}">${badgeText}</span>` : ''}
+          </div>
+          <div class="dl-card-meta">${escapeHtml(formatMeta(d))}</div>
+        </div>
+        <div class="dl-card-right">
+          ${d.size ? `<span class="dl-card-size">${escapeHtml(d.size)}</span>` : ''}
+          <span class="dl-card-btn ${btnClass}">Download</span>
+        </div>
+      </a>
+    `;
+  }
+
+  function renderCodeBlock(lines) {
+    const commands = lines.filter(l => l.type === 'prompt').map(l => l.content).join('\n');
+    const body = lines.map(line => {
+      if (line.type === 'comment') return `<span class="dl-comment">${escapeHtml(line.content)}</span>\n`;
+      if (line.type === 'prompt') return `<span class="dl-prompt">${escapeHtml(line.promptChar || '$')}</span> ${escapeHtml(line.content)}\n`;
+      return `${escapeHtml(line.content)}\n`;
+    }).join('');
+    return '<div class="dl-code-block"><button type="button" class="dl-copy-btn" data-copy="' + escapeHtml(commands) + '">Copy</button>' + body + '</div>';
+  }
+
+  function renderTerminalTip(os) {
+    const t = getTerminalTipContent(os);
+    return `
+      <details class="dl-details dl-terminal-tip">
+        <summary class="dl-toggle dl-toggle-terminal-tip"><span class="dl-arrow">&#9654;</span> New to the terminal?</summary>
+        <div class="dl-terminal-tip-content">
+          <p>${t.openHow}</p>
+          <p>The ${t.promptChar} symbol shown before each command is the <strong>prompt</strong> — it means “type here.” Don’t type it yourself; just type the text that comes after it, then press <strong>Enter</strong>.</p>
+          <p>The <strong>Copy</strong> button in the top-right of each code block copies only the commands (without the prompt), ready to paste.</p>
+        </div>
+      </details>
+    `;
+  }
+
+  function renderOsNote(note, idx) {
+    const variantClass = note.variant === 'warning' ? 'dl-os-note-warning' : note.variant === 'info' ? 'dl-os-note-info' : '';
+    const icon = note.variant === 'warning' ? '⚠️' : note.variant === 'info' ? 'ℹ️' : '💡';
+    const issuesHtml = (note.issues && note.issues.length > 0) ? `
+      <details class="dl-linked-issues" data-note-index="${idx}">
+        <summary class="dl-linked-issues-toggle"><span class="dl-arrow">&#9654;</span> Linked Issues <span class="dl-linked-issues-count">${note.issues.length}</span></summary>
+        <div class="dl-linked-issues-items"></div>
+      </details>
+    ` : '';
+
+    return `
+      <div class="dl-os-note ${variantClass}">
+        <span class="dl-os-note-icon">${icon}</span>
+        <div class="dl-os-note-content">
+          <div class="dl-os-note-title">${note.title}</div>
+          <p>${note.content}</p>
+          ${issuesHtml}
+        </div>
+      </div>
+    `;
+  }
+
+  function renderLinkedIssueItem(item) {
+    const typeBadge = item.type ? `<span class="dl-issue-type-badge">${item.type === 'pr' ? 'PR' : 'Issue'}</span>` : '';
+    const statusBadge = item.status
+      ? `<span class="dl-issue-status ${item.status === 'open' ? 'dl-issue-status-open' : 'dl-issue-status-closed'}">${item.status === 'open' ? '●' : '✓'}</span>`
+      : '';
+    const chips = (item.labels || []).map(l => {
+      const c = escapeHtml(l.color);
+      return `<span class="dl-issue-label-chip" style="color:#${c};background:#${c}26;border-color:#${c}73;">${escapeHtml(l.name)}</span>`;
+    }).join('');
+
+    return `
+      <a href="${escapeHtml(item.url)}" target="_blank" rel="noopener noreferrer" class="dl-linked-issue-item">
+        ${typeBadge}${statusBadge}
+        <span>&#9671; ${escapeHtml(item.label)}</span>
+        ${chips}
+        <span class="dl-linked-issue-arrow">&#8599;</span>
+      </a>
+    `;
+  }
+
+  function wireLinkedIssues(container, notes) {
+    container.querySelectorAll('.dl-linked-issues').forEach(detailsEl => {
+      const idx = Number(detailsEl.dataset.noteIndex);
+      const note = notes[idx];
+      if (!note) return;
+      let loaded = false;
+      detailsEl.addEventListener('toggle', () => {
+        if (!detailsEl.open || loaded) return;
+        loaded = true;
+        const itemsEl = detailsEl.querySelector('.dl-linked-issues-items');
+        itemsEl.innerHTML = '<div class="dl-linked-issue-loading">Loading&hellip;</div>';
+        Promise.all(note.issues.map(async issue => {
+          const meta = await fetchIssueMetadata(issue.url);
+          return Object.assign({}, issue, meta || {});
+        })).then(enriched => {
+          itemsEl.innerHTML = enriched.map(renderLinkedIssueItem).join('');
+        });
+      });
+    });
+  }
+
+  function wireCopyButtons(container) {
+    container.querySelectorAll('.dl-copy-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        navigator.clipboard.writeText(btn.dataset.copy || '').then(() => {
+          btn.textContent = 'Copied!';
+          btn.classList.add('dl-copy-btn-copied');
+          setTimeout(() => {
+            btn.textContent = 'Copy';
+            btn.classList.remove('dl-copy-btn-copied');
+          }, 2000);
+        }, () => {
+          btn.textContent = 'Copy failed';
+          setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+        });
+      });
+    });
+  }
+
+  function renderDownloadSection(opts) {
+    const blockClass = opts.sectionVariant === 'primary' ? 'dl-section-block' : 'dl-section-block dl-section-block-secondary';
+    const cardVariant = opts.sectionVariant === 'primary' ? 'recommended' : 'server-rec';
+    const notesHtml = (opts.notes || []).map((n, i) => renderOsNote(n, opts.notesStartIndex + i)).join('');
+
+    const downloadsHtml = (opts.recommended.length === 0 && opts.noDetectMessage)
+      ? `<div class="dl-no-detect">${escapeHtml(opts.noDetectMessage)}</div>`
+      : opts.recommended.map(d => renderCard(d, cardVariant, opts.version)).join('');
+
+    const alternatesHtml = (opts.alternates && opts.alternates.length > 0) ? `
+      <div class="dl-alt-format-label">Also available for your system</div>
+      <div class="dl-downloads">${opts.alternates.map(d => renderCard(d, 'secondary', opts.version)).join('')}</div>
+    ` : '';
+
+    let instructionsHtml = '';
+    if (opts.installInstructions.length > 0) {
+      const blocksHtml = opts.installInstructions.map(block => block.codeLines ? renderCodeBlock(block.codeLines) : `<p>${block.text}</p>`).join('');
+      const tipHtml = (opts.showTerminalTip && opts.terminalTipOs) ? renderTerminalTip(opts.terminalTipOs) : '';
+      instructionsHtml = `
+        <details class="dl-details">
+          <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> Install instructions</summary>
+          <div class="dl-section-details-content">${blocksHtml}${tipHtml}</div>
+        </details>
+      `;
+    }
+
+    return `
+      <div class="${blockClass}">
+        <div class="dl-section-header">
+          <div class="dl-section-title"><span class="dl-section-title-icon">${opts.icon}</span> ${escapeHtml(opts.title)}</div>
+          <div class="dl-section-subtitle">${opts.subtitleHtml}</div>
+          <details class="dl-details">
+            <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> ${escapeHtml(opts.detailsLabel)}</summary>
+            <div class="dl-section-details-content">${opts.detailsContentHtml}</div>
+          </details>
+        </div>
+        ${notesHtml}
+        <div class="dl-downloads">${downloadsHtml}</div>
+        ${alternatesHtml}
+        ${instructionsHtml}
+      </div>
+    `;
+  }
+
+  function renderTerminalInstallSection(os, arch, variant, version) {
+    if (os === 'windows' || os === 'unknown') return '';
+    const blocks = getTerminalInstallBlocks(os, arch, variant, version);
+    if (blocks.length === 0) return '';
+    const blocksHtml = blocks.map(b => b.codeLines ? renderCodeBlock(b.codeLines) : '').join('');
+    return `
+      <details class="dl-details">
+        <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> Install from terminal</summary>
+        <div class="dl-section-label" style="margin-top:8px">One-liner install from terminal</div>
+        <p class="dl-install-hint">Download and run directly using <code>curl</code>.</p>
+        ${blocksHtml}
+        ${renderTerminalTip(os)}
+      </details>
+    `;
+  }
+
+  function renderAllPlatformsSection(otherApp, otherServer, version, defaultOpen) {
+    if (otherApp.length === 0 && otherServer.length === 0) return '';
+    const appHtml = otherApp.length > 0 ? `
+      <div class="dl-section-label" style="margin-top:8px">App Installer — other platforms</div>
+      <div class="dl-downloads">${otherApp.map(d => renderCard(d, 'secondary', version)).join('')}</div>
+    ` : '';
+    const serverHtml = otherServer.length > 0 ? `
+      <div class="dl-section-label" style="margin-top:24px">Backend Server — other platforms</div>
+      <div class="dl-downloads">${otherServer.map(d => renderCard(d, 'secondary', version)).join('')}</div>
+    ` : '';
+    return `
+      <details class="dl-details"${defaultOpen ? ' open' : ''}>
+        <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> All platforms &amp; formats</summary>
+        ${appHtml}
+        ${serverHtml}
+      </details>
+    `;
+  }
+
+  function renderLegacyView(assets, tagName) {
+    const downloadable = assets.filter(a => (!a.name.endsWith('.tar.gz') && !a.name.endsWith('.zip')) || a.name.includes('freemocap'));
+    const itemsHtml = downloadable.map(a => `
+      <a href="${escapeHtml(a.browser_download_url)}" class="dl-legacy-asset">
+        <span class="dl-legacy-asset-name">${escapeHtml(a.name)}</span>
+        <span class="dl-legacy-asset-size">${escapeHtml(formatBytes(a.size))}</span>
+      </a>
+    `).join('');
+
+    return `
+      <div class="dl-legacy-notice">
+        <span class="dl-legacy-notice-icon">📦</span>
+        <div>This release (<strong>${escapeHtml(tagName)}</strong>) predates our smart download page. Here are all available files — pick the one that matches your system.</div>
+      </div>
+      <div class="dl-legacy-asset-list">${itemsHtml}</div>
+    `;
+  }
+
+  // ── state ────────────────────────────────────────────────
+  const state = {
+    os: 'unknown',
+    arch: 'x64',
+    hasManualSystem: false,
+    variant: 'cpu',
+    gpuDetected: false,
+    hasManualVariant: false,
+    tag: `v${DEFAULT_VERSION}`,
+    hasManualVersion: false,
+    releases: [],
+    releasesLoading: true,
+    r2Sizes: {},
+  };
+
+  function currentActiveNotes() {
+    return OS_NOTES.filter(n => n.os === state.os && (n.arch === undefined || n.arch === state.arch));
+  }
+
+  function renderSystemDetector() {
+    const textEl = document.getElementById('dl-detected-text');
+    const label = OS_LABELS[state.os] || state.os;
+    textEl.innerHTML = `Detected: <strong>${escapeHtml(label)} · ${escapeHtml(archLabel(state.arch))}</strong>`;
+    document.querySelectorAll('#dl-os-pills .dl-pill').forEach(btn => {
+      btn.classList.toggle('dl-pill-active', btn.dataset.os === state.os && btn.dataset.arch === state.arch);
+    });
+  }
+
+  function renderVariantDetector() {
+    const row = document.getElementById('dl-variant-detect');
+    const show = state.os !== 'unknown' && hasVariant(state.os, state.arch);
+    row.hidden = !show;
+    if (!show) return;
+
+    document.getElementById('dl-variant-detected-text').innerHTML = state.gpuDetected
+      ? 'Detected: <strong>NVIDIA GPU</strong>'
+      : 'No GPU detected, recommending <strong>CPU-only</strong>';
+
+    document.querySelectorAll('#dl-variant-pills .dl-pill').forEach(btn => {
+      btn.classList.toggle('dl-pill-active', btn.dataset.variant === state.variant);
+    });
+  }
+
+  function renderVersionSelect() {
+    const row = document.getElementById('dl-version-row');
+    const select = document.getElementById('dl-version-select');
+    if (state.releasesLoading || state.releases.length === 0) {
+      row.hidden = true;
+      return;
+    }
+    row.hidden = false;
+
+    if (select.options.length === 0) {
+      select.innerHTML = state.releases.map((r, i) => {
+        let label = r.tag_name;
+        if (i === 0) label += ' (latest)';
+        if (r.prerelease) label += ' · pre-release';
+        return `<option value="${escapeHtml(r.tag_name)}">${escapeHtml(label)}</option>`;
+      }).join('');
+    }
+    select.value = state.tag;
+  }
+
+  function renderMainContent() {
+    const container = document.getElementById('dl-content');
+    const version = stripVersionPrefix(state.tag);
+    const selectedRelease = state.releases.find(r => r.tag_name === state.tag);
+    const isLegacy = selectedRelease ? !matchesExpectedPattern(selectedRelease.assets, version) : false;
+
+    if (isLegacy && selectedRelease) {
+      container.innerHTML = renderLegacyView(selectedRelease.assets, selectedRelease.tag_name);
+      return;
+    }
+
+    let appDownloads = buildAppDownloads(version);
+    let serverDownloads = buildServerDownloads(version);
+    if (selectedRelease) {
+      appDownloads = enrichDownloadsWithAssets(appDownloads, selectedRelease.assets);
+      serverDownloads = enrichDownloadsWithAssets(serverDownloads, selectedRelease.assets);
+    }
+    appDownloads = enrichDownloadsWithR2Sizes(appDownloads, version, state.r2Sizes);
+    serverDownloads = enrichDownloadsWithR2Sizes(serverDownloads, version, state.r2Sizes);
+
+    const matchesVariant = d => !d.variant || d.variant === state.variant;
+    const recApp = [], altApp = [], otherApp = [];
+    appDownloads.forEach(d => {
+      if (d.os === state.os && d.arch === state.arch && matchesVariant(d)) {
+        (d.recommended ? recApp : altApp).push(d);
+      } else {
+        otherApp.push(d);
+      }
+    });
+    const recServer = [], otherServer = [];
+    serverDownloads.forEach(d => {
+      if (d.os === state.os && d.arch === state.arch && matchesVariant(d)) recServer.push(d);
+      else otherServer.push(d);
+    });
+
+    const isUnavailablePlatform = state.os !== 'unknown' && recApp.length === 0 && altApp.length === 0 && recServer.length === 0;
+    const osForInstructions = state.os === 'unknown' ? undefined : state.os;
+    const showVariantPicker = state.os !== 'unknown' && hasVariant(state.os, state.arch);
+    const variantForInstructions = showVariantPicker ? state.variant : undefined;
+
+    const appInstructions = (osForInstructions && !isUnavailablePlatform) ? getAppInstallInstructions(osForInstructions, state.arch, variantForInstructions, version) : [];
+    const serverInstructions = (osForInstructions && !isUnavailablePlatform) ? getServerInstallInstructions(osForInstructions, state.arch, variantForInstructions, version) : [];
+
+    const activeNotes = currentActiveNotes();
+    const noDetect = state.os === 'unknown';
+    const terminalTipOs = (osForInstructions && osForInstructions !== 'windows') ? osForInstructions : undefined;
+
+    let html = renderDownloadSection({
+      icon: '💀📸',
+      title: 'FreeMoCap App Installer',
+      subtitleHtml: '<strong>Recommended</strong> — this is what most people want',
+      detailsLabel: "What's included?",
+      detailsContentHtml: 'Desktop application with camera preview, recording controls, and settings. The backend server is already bundled inside — you don’t need to download it separately.',
+      recommended: recApp,
+      alternates: altApp,
+      installInstructions: appInstructions,
+      version,
+      sectionVariant: 'primary',
+      noDetectMessage: noDetect ? 'Could not detect your OS. See all downloads below.' : undefined,
+      showTerminalTip: osForInstructions === 'linux',
+      terminalTipOs,
+      notes: activeNotes,
+      notesStartIndex: 0,
+    });
+
+    if (!isUnavailablePlatform) {
+      html += renderTerminalInstallSection(state.os, state.arch, variantForInstructions, version);
+      html += '<hr class="dl-section-divider">';
+      html += renderDownloadSection({
+        icon: '⚡',
+        title: 'FreeMoCap Backend Server',
+        subtitleHtml: '<strong>Advanced</strong> — headless machines, remote capture rigs, API use',
+        detailsLabel: 'When do I need this?',
+        detailsContentHtml: 'Just the camera backend server binary, no GUI. Useful for headless capture rigs, remote systems you connect to over a network, or building a custom client against the FreeMoCap API. <strong>You don’t need this if you downloaded the App Installer above.</strong>',
+        recommended: recServer,
+        alternates: null,
+        installInstructions: serverInstructions,
+        version,
+        sectionVariant: 'secondary',
+        showTerminalTip: osForInstructions != null && osForInstructions !== 'windows',
+        terminalTipOs,
+        notes: [],
+        notesStartIndex: activeNotes.length,
+      });
+    }
+
+    html += renderAllPlatformsSection(otherApp, otherServer, version, noDetect);
+
+    container.innerHTML = html;
+    wireLinkedIssues(container, activeNotes);
+    wireCopyButtons(container);
+  }
+
+  function render() {
+    renderSystemDetector();
+    renderVariantDetector();
+    renderVersionSelect();
+    renderMainContent();
+  }
+
+  // ── R2 sizes (re-fetched whenever the selected version changes) ──
+  function refreshR2Sizes() {
+    const version = stripVersionPrefix(state.tag);
+    const all = [...buildAppDownloads(version), ...buildServerDownloads(version)];
+    const urls = all.filter(d => isR2Hosted(d.os, d.variant)).map(d => downloadUrl(d.file, d.os, version, d.variant));
+    if (urls.length === 0) return;
+    fetchR2Sizes(urls).then(sizes => {
+      state.r2Sizes = sizes;
+      render();
+    });
+  }
+
+  // ── init ─────────────────────────────────────────────────
+  const detected = detectSystem();
+  state.os = detected.os;
+  state.arch = detected.arch;
+
+  refineMacArch(arch => {
+    if (!state.hasManualSystem && state.os === 'macos') {
+      state.arch = arch;
+      render();
+    }
+  });
+
+  const gpu = detectGpu();
+  state.variant = gpu.variant;
+  state.gpuDetected = gpu.detected;
+
+  document.querySelectorAll('#dl-os-pills .dl-pill').forEach(btn => {
+    btn.addEventListener('click', () => {
+      state.os = btn.dataset.os;
+      state.arch = btn.dataset.arch;
+      state.hasManualSystem = true;
+      render();
+    });
+  });
+
+  document.querySelectorAll('#dl-variant-pills .dl-pill').forEach(btn => {
+    btn.addEventListener('click', () => {
+      state.variant = btn.dataset.variant;
+      state.hasManualVariant = true;
+      render();
+    });
+  });
+
+  document.getElementById('dl-version-select').addEventListener('change', e => {
+    state.tag = e.target.value;
+    state.hasManualVersion = true;
+    render();
+    refreshR2Sizes();
+  });
+
+  render();
+
+  try {
+    const releases = await fetchReleases();
+    state.releases = releases;
+    state.releasesLoading = false;
+    if (releases.length > 0 && !state.hasManualVersion) {
+      state.tag = releases[0].tag_name;
+    }
+    render();
+    refreshR2Sizes();
+  } catch (_) {
+    state.releasesLoading = false;
+    render();
+  }
+})();

--- a/httpdocs/dist/js/download.js
+++ b/httpdocs/dist/js/download.js
@@ -111,13 +111,13 @@
   const OS_NOTES = [
     {
       os: 'macos', arch: 'x64', variant: 'warning',
-      title: 'Intel Mac builds aren’t available yet',
-      content: 'FreeMoCap’s pose-tracking backend (onnxruntime, via skellytracker) doesn’t currently publish a macOS x86_64 wheel, so we can’t build for Intel Macs yet. If you’re on Apple Silicon, select that option above instead.',
+      title: { app: 'Intel Mac app installer builds aren’t available yet', server: 'Intel Mac backend server builds aren’t available yet' },
+      content: 'FreeMoCap’s pose-tracking backend (onnxruntime, via skellytracker) doesn’t currently publish a macOS x86_64 wheel, so we can’t build for Intel Macs yet. If you’re on Apple Silicon, select that option instead.',
       issues: [{ label: 'Add macOS Intel (x86_64) installer build', url: 'https://github.com/freemocap/freemocap/issues/823' }],
     },
     {
       os: 'linux', arch: 'arm64', variant: 'warning',
-      title: 'Linux ARM64 builds aren’t available',
+      title: { app: 'Linux ARM64 app installer builds aren’t available', server: 'Linux ARM64 backend server builds aren’t available' },
       content: 'We can’t build a Linux ARM64 release (e.g. for Raspberry Pi) yet: mediapipe — a core dependency of the pose-tracking backend — ships no linux-aarch64 wheel, so the build is unsatisfiable on that platform. It’ll stay unavailable until mediapipe publishes ARM64 Linux wheels.',
       issues: [{ label: 'Add Linux ARM64 installer build', url: 'https://github.com/freemocap/freemocap/issues/822' }],
     },
@@ -466,8 +466,9 @@
     `;
   }
 
-  function renderOsNote(note, idx) {
+  function renderOsNote(note, idx, context) {
     const variantClass = note.variant === 'warning' ? 'dl-os-note-warning' : note.variant === 'info' ? 'dl-os-note-info' : '';
+    const title = typeof note.title === 'object' ? note.title[context] : note.title;
     const issuesHtml = (note.issues && note.issues.length > 0) ? `
       <details class="dl-linked-issues" data-note-index="${idx}">
         <summary class="dl-linked-issues-toggle"><span class="dl-arrow">&#9654;</span> Linked Issues <span class="dl-linked-issues-count">${note.issues.length}</span></summary>
@@ -478,7 +479,7 @@
     return `
       <div class="dl-os-note ${variantClass}">
         <div class="dl-os-note-content">
-          <div class="dl-os-note-title">${note.title}</div>
+          <div class="dl-os-note-title">${title}</div>
           <p>${note.content}</p>
           ${issuesHtml}
         </div>
@@ -548,7 +549,7 @@
   function renderDownloadSection(opts) {
     const blockClass = opts.sectionVariant === 'primary' ? 'dl-section-block' : 'dl-section-block dl-section-block-secondary';
     const cardVariant = opts.sectionVariant === 'primary' ? 'recommended' : 'server-rec';
-    const notesHtml = (opts.notes || []).map((n, i) => renderOsNote(n, opts.notesStartIndex + i)).join('');
+    const notesHtml = (opts.notes || []).map((n, i) => renderOsNote(n, opts.notesStartIndex + i, opts.noteContext)).join('');
 
     const downloadsHtml = (opts.recommended.length === 0 && opts.noDetectMessage)
       ? `<div class="dl-no-detect">${escapeHtml(opts.noDetectMessage)}</div>`
@@ -582,7 +583,7 @@
       `;
 
     return `
-      <div class="${blockClass}">
+      <div class="${blockClass}"${opts.id ? ` id="${opts.id}"` : ''}>
         <div class="dl-section-header">
           <div class="dl-section-title-row">
             <div class="dl-section-title">${opts.icon ? `<span class="dl-section-title-icon">${opts.icon}</span> ` : ''}${escapeHtml(opts.title)}</div>
@@ -613,21 +614,26 @@
     `;
   }
 
-  function renderAllPlatformsSection(otherApp, otherServer, version, defaultOpen) {
+  function renderAllPlatformsSection(otherApp, otherServer, version) {
     if (otherApp.length === 0 && otherServer.length === 0) return '';
     const appHtml = otherApp.length > 0 ? `
+      <div class="dl-all-platforms-subheader">App Installer</div>
       <div class="dl-downloads">${otherApp.map(d => renderCard(d, 'secondary', version)).join('')}</div>
     ` : '';
     const serverHtml = otherServer.length > 0 ? `
-      <div class="dl-section-label" style="margin-top:24px">Backend Server — other platforms</div>
+      <div class="dl-all-platforms-subheader">Backend Server</div>
       <div class="dl-downloads">${otherServer.map(d => renderCard(d, 'secondary', version)).join('')}</div>
     ` : '';
     return `
-      <details class="dl-details"${defaultOpen ? ' open' : ''}>
-        <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> All platforms &amp; formats</summary>
+      <div class="dl-section-block dl-section-block-secondary">
+        <div class="dl-section-header">
+          <div class="dl-section-title-row">
+            <div class="dl-section-title">All Platforms &amp; Formats</div>
+          </div>
+        </div>
         ${appHtml}
         ${serverHtml}
-      </details>
+      </div>
     `;
   }
 
@@ -763,6 +769,7 @@
     const primaryHtml = renderDownloadSection({
       icon: '',
       title: 'App Installer',
+      id: 'app-installer',
       leadHtml: '<strong>Recommended.</strong> Desktop application with camera preview, recording controls, and settings. The backend server is already bundled inside, meaning you don’t need to download it separately.',
       recommended: recApp,
       alternates: altApp,
@@ -774,6 +781,7 @@
       terminalTipOs,
       notes: activeNotes,
       notesStartIndex: 0,
+      noteContext: 'app',
       terminalInstallHtml: !isUnavailablePlatform ? renderTerminalInstallSection(state.os, state.arch, variantForInstructions, version) : '',
     });
 
@@ -793,30 +801,31 @@
     const titleRow = primaryContainer.querySelector('.dl-section-title-row');
     if (titleRow && versionRow) titleRow.appendChild(versionRow);
 
-    let secondaryHtml = '';
-    if (!isUnavailablePlatform) {
-      secondaryHtml += '<hr class="dl-section-divider">';
-      secondaryHtml += renderDownloadSection({
-        icon: '',
-        title: 'FreeMoCap Backend Server',
-        subtitleHtml: '<strong>Advanced.</strong> Headless machines, remote capture rigs, API use.',
-        detailsLabel: 'When do I need this?',
-        detailsContentHtml: 'Just the camera backend server binary, no GUI. Useful for headless capture rigs, remote systems you connect to over a network, or building a custom client against the FreeMoCap API. <strong>You don’t need this if you downloaded the App Installer above.</strong>',
-        recommended: recServer,
-        alternates: null,
-        installInstructions: serverInstructions,
-        version,
-        sectionVariant: 'secondary',
-        showTerminalTip: osForInstructions != null && osForInstructions !== 'windows',
-        terminalTipOs,
-        notes: [],
-        notesStartIndex: activeNotes.length,
-      });
-    }
+    let secondaryHtml = '<hr class="dl-section-divider">';
+    secondaryHtml += renderDownloadSection({
+      icon: '',
+      title: 'Backend Server',
+      id: 'backend-server',
+      subtitleHtml: '<strong>Advanced.</strong> Headless machines, remote capture rigs, API use.',
+      detailsLabel: 'When do I need this?',
+      detailsContentHtml: 'Just the camera backend server binary, no GUI. Useful for headless capture rigs, remote systems you connect to over a network, or building a custom client against the FreeMoCap API. <strong>You don’t need this if you downloaded the App Installer above.</strong>',
+      recommended: recServer,
+      alternates: null,
+      installInstructions: serverInstructions,
+      version,
+      sectionVariant: 'secondary',
+      showTerminalTip: osForInstructions != null && osForInstructions !== 'windows',
+      terminalTipOs,
+      notes: activeNotes,
+      notesStartIndex: 0,
+      noteContext: 'server',
+    });
 
-    secondaryHtml += renderAllPlatformsSection(otherApp, otherServer, version, noDetect);
+    secondaryHtml += '<hr class="dl-section-divider">';
+    secondaryHtml += renderAllPlatformsSection(otherApp, otherServer, version);
 
     secondaryContainer.innerHTML = secondaryHtml;
+    wireLinkedIssues(secondaryContainer, activeNotes);
     wireCopyButtons(secondaryContainer);
   }
 

--- a/httpdocs/dist/js/nav.js
+++ b/httpdocs/dist/js/nav.js
@@ -56,6 +56,7 @@
     'showcase.html': 'community', // showcase lives under Community
     'resources.html':'resources',
     'data.html':     'data',
+    'download.html': 'download',
   };
 
   const activeNav = activeMap[page] || (isIndex ? null : null);


### PR DESCRIPTION
## Summary
- Replaces the external redirect to docs.freemocap.org with a real in-house /download page: OS/GPU auto-detection, live GitHub release data, per-platform install instructions and terminal one-liners, and the Linux CUDA build's Cloudflare R2 hosting special case
- Redesigns the page to lead with the actual download button instead of system-detection details first, with a shared page-hero, intro copy linking to the App Installer / Backend Server sections, and a permanently visible All Platforms & Formats section
- Makes the Backend Server section always visible instead of hidden entirely on platforms with no builds (Intel Mac, Linux ARM64), reusing the same unavailability note already shown for the App Installer, with section-aware wording

## Test plan
- [ ] Load /download on each detected OS (Windows, macOS Apple Silicon, macOS Intel, Linux x64, Linux ARM64) and confirm the recommended download card and install instructions are correct
- [ ] Confirm the version picker still works and switching versions updates download links/sizes
- [ ] Confirm the intro section's "App Installer" / "backend server binary" links scroll to the right sections
- [ ] Spot check on mobile width

🤖 Generated with [Claude Code](https://claude.com/claude-code)