### PR TITLE
Redesign download page OS/GPU picker and install instructions

### DIFF
--- a/httpdocs/dist/css/main.css
+++ b/httpdocs/dist/css/main.css
@@ -1711,94 +1711,10 @@ section[id] {
   opacity: 0.5;
 }
 
-/* Wraps the OS/GPU detect rows now that they sit below the primary download,
-   as a secondary "not right? change it" control rather than a gate in front
-   of the download itself. */
+/* Wraps the "not sure what system you have?" help collapsible below the
+   primary download. */
 .dl-detect-zone {
   margin-bottom: 1.5rem;
-}
-
-/* Download page detect rows */
-.dl-detect-row {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.5rem;
-}
-
-.dl-detect-row:last-of-type {
-  margin-bottom: 0;
-}
-
-.dl-detect-row[hidden] {
-  display: none;
-}
-
-.dl-detected {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: var(--bg-tertiary);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 8px;
-  padding: 0.6rem 1rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-}
-
-.dl-dot {
-  width: 6px;
-  height: 6px;
-  background: var(--accent-teal);
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.dl-detected strong {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-
-.dl-wrong-detect {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.68rem;
-  color: var(--text-muted);
-}
-
-.dl-pills {
-  display: flex;
-  gap: 0.25rem;
-  background: var(--bg-tertiary);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 8px;
-  padding: 0.25rem;
-  flex-wrap: wrap;
-}
-
-.dl-pill {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.68rem;
-  padding: 0.4rem 0.6rem;
-  border-radius: 5px;
-  border: none;
-  cursor: pointer;
-  background: transparent;
-  color: var(--text-muted);
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.dl-pill:hover {
-  color: var(--text-primary);
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.dl-pill.dl-pill-active {
-  color: var(--accent-teal);
-  background: rgba(125, 184, 183, 0.18);
-  font-weight: 600;
 }
 
 /* Download page system help / collapsibles (native <details>) */
@@ -1938,6 +1854,7 @@ details[open] > .dl-toggle .dl-arrow {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 6px;
   padding: 0.4rem 0.6rem;
+  width: 13rem;
   cursor: pointer;
   transition: border-color 0.15s ease;
 }
@@ -1946,17 +1863,46 @@ details[open] > .dl-toggle .dl-arrow {
   border-color: var(--accent-teal);
 }
 
+/* Download page OS selector, mirrors .dl-version-row/.dl-version-select */
+.dl-os-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.dl-os-select {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  width: 13rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.dl-os-select:hover {
+  border-color: var(--accent-teal);
+}
+
 .dl-detect-zone .dl-system-help {
-  margin-top: 1rem;
+  margin-top: 0.2rem;
   margin-bottom: 1rem;
 }
 
-/* Download page section blocks. #dl-primary leads with plain .dl-section-block
-   (bigger, since it's the first thing after the compact detect rows), while
-   the server section in #dl-secondary adds .dl-section-block-secondary on
-   top to de-emphasize it. */
+/* Download page section blocks. #dl-primary leads with plain .dl-section-block,
+   given only a small margin-bottom so its trailing "Install from terminal"
+   toggle and the "Not sure what system you have?" help toggle right after it
+   in .dl-detect-zone read as one evenly-spaced stack (see .dl-details above),
+   while the server section in #dl-secondary adds .dl-section-block-secondary
+   on top to de-emphasize it. */
 .dl-section-block {
-  margin: 0 0 1rem;
+  margin: 0 0 0.2rem;
 }
 
 .dl-section-block-secondary {
@@ -1969,18 +1915,44 @@ details[open] > .dl-toggle .dl-arrow {
 
 .dl-section-title-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 1rem;
 }
 
+/* Wraps the version and OS selects once they're moved next to the section
+   title (see renderMainContent in download.js), stacking them instead of
+   letting .dl-section-title-row's own flex row put them side by side. */
+.dl-title-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+}
+
 /* Neutralize the standalone version-row's own bottom margin once it's
-   living inline next to the section title instead of stacked in the
-   detect zone, so it centers cleanly against the title instead of
-   sitting low. */
+   living inline instead of stacked in the detect zone, so it centers
+   cleanly against whatever it's paired with (the lead paragraph normally,
+   the title itself for a legacy release, see .dl-section-lead-row below
+   and attachTitleControls in download.js) instead of sitting low. */
+.dl-section-lead-row .dl-version-row,
 .dl-section-title-row .dl-version-row {
   margin-bottom: 0;
+}
+
+/* Row below the title: the leadHtml paragraph (App Installer only, see
+   renderDownloadSection in download.js) alongside .dl-title-controls,
+   which attachTitleControls() appends here at render time. See
+   .dl-section-lead below for why the paragraph needs its own flex-basis
+   here rather than relying on this row's layout alone. */
+.dl-section-lead-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.5rem;
 }
 
 .dl-section-title {
@@ -2018,12 +1990,20 @@ details[open] > .dl-toggle .dl-arrow {
 }
 
 /* Always-visible replacement for the subtitle + collapsible-details pair,
-   used by sections that pass leadHtml instead of subtitleHtml/detailsLabel. */
+   used by sections that pass leadHtml instead of subtitleHtml/detailsLabel.
+   flex-basis is a fixed 240px rather than 0 or auto: 0 would starve this
+   down to nothing once .dl-title-controls's fixed-width selects claim
+   their space on narrow screens (that width should trigger a wrap instead),
+   auto would size it off the paragraph's full unwrapped text length and
+   wrap .dl-title-controls onto its own line even on desktop, where there's
+   plenty of room. min-width matches so it never shrinks past that floor,
+   it only grows beyond it via flex-grow when space allows. */
 .dl-section-lead {
   color: var(--text-secondary);
   font-size: 0.9rem;
   line-height: 1.6;
-  margin-top: 0.5rem;
+  flex: 1 1 240px;
+  min-width: 240px;
 }
 
 .dl-section-lead strong {
@@ -2596,9 +2576,9 @@ details[open] > .dl-toggle .dl-arrow {
 }
 
 /* Download page focus visibility */
-.dl-pill:focus-visible,
 .dl-toggle:focus-visible,
 .dl-version-select:focus-visible,
+.dl-os-select:focus-visible,
 .dl-copy-btn:focus-visible,
 .dl-card:focus-visible,
 .dl-linked-issues-toggle:focus-visible,
@@ -2953,11 +2933,6 @@ details[open] > .dl-toggle .dl-arrow {
   .dl-card-right {
     align-self: stretch;
     justify-content: space-between;
-  }
-
-  .dl-detect-row {
-    flex-direction: column;
-    align-items: flex-start;
   }
 
   .dl-legacy-asset {

--- a/httpdocs/dist/download.html
+++ b/httpdocs/dist/download.html
@@ -34,7 +34,7 @@
     <div class="container">
       <h1 class="page-hero-title">Download FreeMoCap</h1>
       <p class="page-hero-subtitle">
-        Free, open-source markerless motion capture.
+        Free and open-source markerless motion capture.
       </p>
       <div class="dl-repo-links">
         <a href="https://github.com/freemocap/freemocap">GitHub</a>
@@ -46,50 +46,12 @@
     </div>
   </section>
 
-  <!-- Intro Section -->
-  <section class="showcase-intro-section">
-    <div class="container">
-      <div class="about-content">
-        <p class="about-text text-center">
-          Record with ordinary cameras and reconstruct full-body 3D movement without suits, markers, or expensive hardware. Download the official FreeMoCap <a href="#app-installer">App Installer</a> for your system, or get the <a href="#backend-server">backend server binary</a> for headless rigs and advanced setups.
-        </p>
-      </div>
-    </div>
-  </section>
-
   <section class="dl-page">
     <div class="container dl-container">
 
       <div id="dl-primary"></div>
 
       <div class="dl-detect-zone">
-        <div class="dl-detect-row" id="dl-system-detect">
-          <div class="dl-detected">
-            <span class="dl-dot"></span>
-            <span id="dl-detected-text">Detecting your system&hellip;</span>
-          </div>
-          <span class="dl-wrong-detect">Not right? Select your system:</span>
-          <div class="dl-pills" id="dl-os-pills" role="group" aria-label="Select your operating system">
-            <button type="button" class="dl-pill" data-os="windows" data-arch="x64">Windows</button>
-            <button type="button" class="dl-pill" data-os="macos" data-arch="arm64">Mac (Apple Silicon)</button>
-            <button type="button" class="dl-pill" data-os="macos" data-arch="x64">Mac (Intel)</button>
-            <button type="button" class="dl-pill" data-os="linux" data-arch="x64">Linux x64</button>
-            <button type="button" class="dl-pill" data-os="linux" data-arch="arm64">Linux ARM64</button>
-          </div>
-        </div>
-
-        <div class="dl-detect-row" id="dl-variant-detect" hidden>
-          <div class="dl-detected">
-            <span class="dl-dot"></span>
-            <span id="dl-variant-detected-text"></span>
-          </div>
-          <span class="dl-wrong-detect">Not right? Select a build:</span>
-          <div class="dl-pills" id="dl-variant-pills" role="group" aria-label="Select GPU or CPU build">
-            <button type="button" class="dl-pill" data-variant="cuda">GPU (CUDA)</button>
-            <button type="button" class="dl-pill" data-variant="cpu">CPU only</button>
-          </div>
-        </div>
-
         <div class="dl-system-help">
           <details class="dl-details dl-details-help">
             <summary class="dl-toggle dl-toggle-help"><span class="dl-arrow">&#9654;</span> Not sure what system you have?</summary>
@@ -101,7 +63,7 @@
                   <li>If <strong>Chip</strong> says <strong>Apple M1, M2, M3, M4</strong> (or similar) &rarr; you&rsquo;re on <strong>Apple Silicon (ARM64)</strong></li>
                   <li>If <strong>Processor</strong> says <strong>Intel Core i5, i7, i9</strong> etc &rarr; you&rsquo;re on <strong>Intel (x64)</strong></li>
                 </ul>
-                <p>Or run in Terminal: <code>uname -m</code> &mdash; it prints <code>arm64</code> or <code>x86_64</code>.</p>
+                <p>Or run in Terminal: <code>uname -m</code> which prints either <code>arm64</code> or <code>x86_64</code>.</p>
               </div>
               <div class="dl-help-section">
                 <div class="dl-help-section-title"><span class="dl-install-term">Linux</span> x64 or ARM64?</div>
@@ -116,13 +78,13 @@
               <div class="dl-help-section">
                 <div class="dl-help-section-title"><span class="dl-install-term">Linux</span> AppImage or .deb?</div>
                 <ul>
-                  <li><strong>AppImage</strong> &mdash; works on any Linux distro (Ubuntu, Fedora, Arch, etc). Just download and run. No install, no root. Best choice if you&rsquo;re not sure.</li>
-                  <li><strong>.deb</strong> &mdash; for Debian-based distros (Ubuntu, Pop!_OS, Linux Mint, Raspberry Pi OS). Integrates with your package manager so it appears in your app launcher and can be cleanly uninstalled.</li>
+                  <li><strong>AppImage</strong> works on any Linux distro (Ubuntu, Fedora, Arch, etc). If you&rsquo;re not sure, choose this one.</li>
+                  <li><strong>.deb</strong> for Debian-based distros (Ubuntu, Pop!_OS, Linux Mint, Raspberry Pi OS). Integrates with your package manager so it appears in your app launcher and can be cleanly uninstalled.</li>
                 </ul>
               </div>
               <div class="dl-help-section">
                 <div class="dl-help-section-title"><span class="dl-install-term">Windows</span></div>
-                <p>FreeMoCap provides a single <strong>x64 (64-bit)</strong> build, which works on virtually all modern Windows PCs &mdash; Intel, AMD, and Snapdragon/ARM laptops. If you have a newer Snapdragon X / Windows on ARM machine, the x64 installer still works via Microsoft&rsquo;s built-in emulation layer. There&rsquo;s only one download &mdash; you don&rsquo;t need to choose.</p>
+                <p>FreeMoCap provides a single <strong>x64 (64-bit)</strong> build, which works on virtually all modern Windows PCs, including Intel, AMD, and Snapdragon/ARM laptops. If you have a newer Snapdragon X / Windows on ARM machine, the x64 installer still works via Microsoft&rsquo;s built-in emulation layer.</p>
               </div>
             </div>
           </details>
@@ -131,6 +93,17 @@
         <div class="dl-version-row" id="dl-version-row" hidden>
           <label for="dl-version-select">Version:</label>
           <select id="dl-version-select" class="dl-version-select"></select>
+        </div>
+
+        <div class="dl-os-row" id="dl-os-row">
+          <label for="dl-os-select">System OS:</label>
+          <select id="dl-os-select" class="dl-os-select">
+            <option value="windows:x64">Windows</option>
+            <option value="macos:arm64">Mac (Apple Silicon)</option>
+            <option value="macos:x64">Mac (Intel)</option>
+            <option value="linux:x64">Linux x64</option>
+            <option value="linux:arm64">Linux ARM64</option>
+          </select>
         </div>
       </div>
 

--- a/httpdocs/dist/js/download.js
+++ b/httpdocs/dist/js/download.js
@@ -190,10 +190,15 @@
     return [];
   }
 
-  function getTerminalInstallBlocks(os, arch, variant, version) {
+  // Split by artifact (was one combined function) so the App Installer
+  // section's "Install from terminal" only ever shows App Installer
+  // commands, and the Backend Server section gets its own equivalent
+  // instead of the two being mixed into a single toggle under App
+  // Installer. Comment/command text is unchanged from the combined
+  // version, just relocated to whichever function matches its artifact.
+  function getAppTerminalInstallBlocks(os, arch, variant, version) {
     if (os !== 'linux' && os !== 'macos') return [];
     const label = fileLabel(os, arch, variant);
-    const srvZip = `freemocap_server_${version}_${label}.zip`;
     const blocks = [];
 
     if (os === 'linux') {
@@ -210,13 +215,6 @@
         { type: 'prompt', content: `curl -fSL -o freemocap.deb "${downloadUrl(deb, os, version, variant)}"`, promptChar: '$' },
         { type: 'prompt', content: 'sudo apt install ./freemocap.deb', promptChar: '$' },
       ] });
-      blocks.push({ codeLines: [
-        { type: 'comment', content: '# Backend Server (headless / remote capture)' },
-        { type: 'prompt', content: `curl -fSL -o freemocap_server.zip "${downloadUrl(srvZip, os, version, variant)}"`, promptChar: '$' },
-        { type: 'prompt', content: 'unzip freemocap_server.zip -d freemocap_server && cd freemocap_server', promptChar: '$' },
-        { type: 'prompt', content: 'chmod +x freemocap_server', promptChar: '$' },
-        { type: 'prompt', content: './freemocap_server', promptChar: '$' },
-      ] });
     }
 
     if (os === 'macos') {
@@ -226,16 +224,37 @@
         { type: 'prompt', content: `curl -fSL -o freemocap.dmg "${downloadUrl(dmg, os, version, variant)}"`, promptChar: '$' },
         { type: 'prompt', content: 'open freemocap.dmg', promptChar: '$' },
       ] });
-      blocks.push({ codeLines: [
+    }
+
+    return blocks;
+  }
+
+  function getServerTerminalInstallBlocks(os, arch, variant, version) {
+    if (os !== 'linux' && os !== 'macos') return [];
+    const label = fileLabel(os, arch, variant);
+    const srvZip = `freemocap_server_${version}_${label}.zip`;
+
+    if (os === 'linux') {
+      return [{ codeLines: [
+        { type: 'comment', content: '# Backend Server (headless / remote capture)' },
+        { type: 'prompt', content: `curl -fSL -o freemocap_server.zip "${downloadUrl(srvZip, os, version, variant)}"`, promptChar: '$' },
+        { type: 'prompt', content: 'unzip freemocap_server.zip -d freemocap_server && cd freemocap_server', promptChar: '$' },
+        { type: 'prompt', content: 'chmod +x freemocap_server', promptChar: '$' },
+        { type: 'prompt', content: './freemocap_server', promptChar: '$' },
+      ] }];
+    }
+
+    if (os === 'macos') {
+      return [{ codeLines: [
         { type: 'comment', content: '# Backend Server' },
         { type: 'prompt', content: `curl -fSL -o freemocap_server.zip "${downloadUrl(srvZip, os, version, variant)}"`, promptChar: '$' },
         { type: 'prompt', content: 'unzip freemocap_server.zip -d freemocap_server && cd freemocap_server', promptChar: '$' },
         { type: 'prompt', content: 'chmod +x freemocap_server && xattr -cr freemocap_server', promptChar: '$' },
         { type: 'prompt', content: './freemocap_server', promptChar: '$' },
-      ] });
+      ] }];
     }
 
-    return blocks;
+    return [];
   }
 
   function getTerminalTipContent(os) {
@@ -572,15 +591,22 @@
       <div class="dl-downloads">${opts.alternates.map(d => renderCard(d, 'secondary', opts.version)).join('')}</div>
     ` : '';
 
+    // Only worth hiding behind a click if there's actually code to hide.
+    // A one- or two-sentence, code-free block (Windows/macOS App Installer)
+    // renders directly instead of gated behind an "Install instructions"
+    // toggle with nothing to justify the click.
     let instructionsHtml = '';
     if (opts.installInstructions.length > 0) {
+      const hasCode = opts.installInstructions.some(block => block.codeLines);
       const blocksHtml = opts.installInstructions.map(block => block.codeLines ? renderCodeBlock(block.codeLines) : `<p>${block.text}</p>`).join('');
       const tipHtml = (opts.showTerminalTip && opts.terminalTipOs) ? renderTerminalTip(opts.terminalTipOs) : '';
-      instructionsHtml = `
+      instructionsHtml = hasCode ? `
         <details class="dl-details">
           <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> Install instructions</summary>
           <div class="dl-section-details-content">${blocksHtml}${tipHtml}</div>
         </details>
+      ` : `
+        <div class="dl-section-details-content">${blocksHtml}${tipHtml}</div>
       `;
     }
 
@@ -627,9 +653,11 @@
     `;
   }
 
-  function renderTerminalInstallSection(os, arch, variant, version) {
-    if (os === 'windows' || os === 'unknown') return '';
-    const blocks = getTerminalInstallBlocks(os, arch, variant, version);
+  // Takes pre-computed blocks (from getAppTerminalInstallBlocks or
+  // getServerTerminalInstallBlocks) rather than computing them itself, so
+  // the same renderer serves both the App Installer and Backend Server
+  // sections without either pulling in the other's commands.
+  function renderTerminalInstallSection(blocks, os) {
     if (blocks.length === 0) return '';
     const blocksHtml = blocks.map(b => b.codeLines ? renderCodeBlock(b.codeLines) : '').join('');
     return `
@@ -840,6 +868,14 @@
     const noDetect = state.os === 'unknown';
     const terminalTipOs = (osForInstructions && osForInstructions !== 'windows') ? osForInstructions : undefined;
 
+    // Computed once and reused for both showTerminalTip (suppresses the
+    // inline "New to the terminal?" tip inside "Install instructions" when
+    // there's also a separate "Install from terminal" toggle that already
+    // carries its own copy of that tip, see renderTerminalInstallSection)
+    // and terminalInstallHtml (the toggle itself) below.
+    const appTerminalBlocks = !isUnavailablePlatform ? getAppTerminalInstallBlocks(state.os, state.arch, variantForInstructions, version) : [];
+    const serverTerminalBlocks = !isUnavailablePlatform ? getServerTerminalInstallBlocks(state.os, state.arch, variantForInstructions, version) : [];
+
     const primaryHtml = renderDownloadSection({
       icon: '',
       title: 'App Installer',
@@ -851,12 +887,12 @@
       version,
       sectionVariant: 'primary',
       noDetectMessage: noDetect ? 'Could not detect your OS. See all downloads below.' : undefined,
-      showTerminalTip: osForInstructions === 'linux',
+      showTerminalTip: appTerminalBlocks.length === 0,
       terminalTipOs,
       notes: activeNotes,
       notesStartIndex: 0,
       noteContext: 'app',
-      terminalInstallHtml: !isUnavailablePlatform ? renderTerminalInstallSection(state.os, state.arch, variantForInstructions, version) : '',
+      terminalInstallHtml: renderTerminalInstallSection(appTerminalBlocks, state.os),
     });
 
     primaryContainer.innerHTML = primaryHtml;
@@ -875,11 +911,12 @@
       installInstructions: serverInstructions,
       version,
       sectionVariant: 'secondary',
-      showTerminalTip: osForInstructions != null && osForInstructions !== 'windows',
+      showTerminalTip: serverTerminalBlocks.length === 0,
       terminalTipOs,
       notes: activeNotes,
       notesStartIndex: 0,
       noteContext: 'server',
+      terminalInstallHtml: renderTerminalInstallSection(serverTerminalBlocks, state.os),
     });
 
     secondaryHtml += '<hr class="dl-section-divider">';

--- a/httpdocs/dist/js/download.js
+++ b/httpdocs/dist/js/download.js
@@ -98,12 +98,6 @@
     return parts.join(' · ');
   }
 
-  const OS_LABELS = { windows: 'Windows x64', macos: 'macOS', linux: 'Linux', unknown: 'Unknown OS' };
-
-  function archLabel(arch) {
-    return arch === 'arm64' ? 'ARM64 / Apple Silicon' : 'x64 / Intel';
-  }
-
   function stripVersionPrefix(tag) {
     return tag.replace(/^v/, '');
   }
@@ -158,7 +152,7 @@
 
     if (os === 'windows') {
       return [
-        { text: 'Download the <code>.zip</code>, extract it, then run the server from inside the extracted folder — it needs its bundled support files alongside it. Starts a local API on port <code>53117</code>.' },
+        { text: 'Download the <code>.zip</code>, extract it, then run the server from inside the extracted folder. Starts a local API on port <code>53117</code>.' },
         { codeLines: [
           { type: 'prompt', content: `Expand-Archive ${zip} -DestinationPath freemocap_server`, promptChar: '>' },
           { type: 'prompt', content: 'cd freemocap_server', promptChar: '>' },
@@ -168,7 +162,7 @@
     }
     if (os === 'macos') {
       return [
-        { text: 'Download the <code>.zip</code>, extract it, then make the binary executable and run it from Terminal — it needs its bundled support files alongside it.' },
+        { text: 'Download the <code>.zip</code>, extract it, then make the binary executable and run it from Terminal.' },
         { codeLines: [
           { type: 'prompt', content: `unzip ${zip} -d freemocap_server`, promptChar: '$' },
           { type: 'prompt', content: 'cd freemocap_server', promptChar: '$' },
@@ -181,7 +175,7 @@
     }
     if (os === 'linux') {
       return [
-        { text: 'Download the <code>.zip</code>, extract it, then make the binary executable and run it — it needs its bundled support files alongside it. Ideal for headless rigs and remote capture machines.' },
+        { text: 'Download the <code>.zip</code>, extract it, then make the binary executable and run it. Ideal for headless rigs and remote capture machines.' },
         { codeLines: [
           { type: 'prompt', content: `unzip ${zip} -d freemocap_server`, promptChar: '$' },
           { type: 'prompt', content: 'cd freemocap_server', promptChar: '$' },
@@ -548,6 +542,24 @@
 
   function renderDownloadSection(opts) {
     const blockClass = opts.sectionVariant === 'primary' ? 'dl-section-block' : 'dl-section-block dl-section-block-secondary';
+
+    // Legacy releases only get a title (so it and the version/OS selects
+    // stay visible, see attachTitleControls in renderMainContent) plus the
+    // flat asset list, none of the detection-driven cards/notes/instructions
+    // below apply since opts.recommended etc. aren't populated for this path.
+    if (opts.legacyHtml) {
+      return `
+        <div class="${blockClass}"${opts.id ? ` id="${opts.id}"` : ''}>
+          <div class="dl-section-header">
+            <div class="dl-section-title-row">
+              <div class="dl-section-title">${opts.icon ? `<span class="dl-section-title-icon">${opts.icon}</span> ` : ''}${escapeHtml(opts.title)}</div>
+            </div>
+          </div>
+          ${opts.legacyHtml}
+        </div>
+      `;
+    }
+
     const cardVariant = opts.sectionVariant === 'primary' ? 'recommended' : 'server-rec';
     const notesHtml = (opts.notes || []).map((n, i) => renderOsNote(n, opts.notesStartIndex + i, opts.noteContext)).join('');
 
@@ -572,22 +584,38 @@
       `;
     }
 
-    const headerBodyHtml = opts.leadHtml
-      ? `<p class="dl-section-lead">${opts.leadHtml}</p>`
-      : `
-        <div class="dl-section-subtitle">${opts.subtitleHtml}</div>
+    const detailsToggleHtml = opts.detailsLabel ? `
         <details class="dl-details">
           <summary class="dl-toggle"><span class="dl-arrow">&#9654;</span> ${escapeHtml(opts.detailsLabel)}</summary>
           <div class="dl-section-details-content">${opts.detailsContentHtml}</div>
         </details>
+      ` : '';
+
+    // leadHtml (App Installer) sits in its own row below the title, sharing
+    // that row with the version/OS controls attachTitleControls() appends
+    // to it (title stays full-width, alone, above both), so it reads as a
+    // natural two-line block next to the dropdowns instead of floating
+    // full-width between the title and the download cards, duplicating the
+    // card's own "Recommended" badge right below it. subtitleHtml (Backend
+    // Server) has no controls beside it, so it stays directly below the
+    // title as before, no separate row needed.
+    const leadRowHtml = opts.leadHtml ? `
+        <div class="dl-section-lead-row">
+          <p class="dl-section-lead">${opts.leadHtml}</p>
+        </div>
+      ` : '';
+    const headerBodyHtml = opts.leadHtml
+      ? ''
+      : `
+        <div class="dl-section-subtitle">${opts.subtitleHtml}</div>
+        ${detailsToggleHtml}
       `;
 
     return `
       <div class="${blockClass}"${opts.id ? ` id="${opts.id}"` : ''}>
         <div class="dl-section-header">
-          <div class="dl-section-title-row">
-            <div class="dl-section-title">${opts.icon ? `<span class="dl-section-title-icon">${opts.icon}</span> ` : ''}${escapeHtml(opts.title)}</div>
-          </div>
+          <div class="dl-section-title">${opts.icon ? `<span class="dl-section-title-icon">${opts.icon}</span> ` : ''}${escapeHtml(opts.title)}</div>
+          ${leadRowHtml}
           ${headerBodyHtml}
         </div>
         ${notesHtml}
@@ -660,8 +688,6 @@
     arch: 'x64',
     hasManualSystem: false,
     variant: 'cpu',
-    gpuDetected: false,
-    hasManualVariant: false,
     tag: `v${DEFAULT_VERSION}`,
     hasManualVersion: false,
     releases: [],
@@ -673,28 +699,18 @@
     return OS_NOTES.filter(n => n.os === state.os && (n.arch === undefined || n.arch === state.arch));
   }
 
-  function renderSystemDetector() {
-    const textEl = document.getElementById('dl-detected-text');
-    const label = OS_LABELS[state.os] || state.os;
-    textEl.innerHTML = `Detected: <strong>${escapeHtml(label)} · ${escapeHtml(archLabel(state.arch))}</strong>`;
-    document.querySelectorAll('#dl-os-pills .dl-pill').forEach(btn => {
-      btn.classList.toggle('dl-pill-active', btn.dataset.os === state.os && btn.dataset.arch === state.arch);
-    });
-  }
-
-  function renderVariantDetector() {
-    const row = document.getElementById('dl-variant-detect');
-    const show = state.os !== 'unknown' && hasVariant(state.os, state.arch);
-    row.hidden = !show;
-    if (!show) return;
-
-    document.getElementById('dl-variant-detected-text').innerHTML = state.gpuDetected
-      ? 'Detected: <strong>NVIDIA GPU</strong>'
-      : 'No GPU detected, recommending <strong>CPU-only</strong>';
-
-    document.querySelectorAll('#dl-variant-pills .dl-pill').forEach(btn => {
-      btn.classList.toggle('dl-pill-active', btn.dataset.variant === state.variant);
-    });
+  function renderOsSelect() {
+    // No option maps to 'unknown' (see download.html), a manual override
+    // list only makes sense with real choices on it. Leave the select on
+    // whatever it's already showing (its default first option, Windows,
+    // on first render) rather than force an unmatched value, which would
+    // clear the visible selection entirely. state.os stays 'unknown'
+    // either way, so the "couldn't detect your OS" messaging below is
+    // unaffected.
+    if (state.os === 'unknown') return;
+    const select = document.getElementById('dl-os-select');
+    const value = `${state.os}:${state.arch}`;
+    if (select.value !== value) select.value = value;
   }
 
   function renderVersionSelect() {
@@ -724,8 +740,43 @@
     const selectedRelease = state.releases.find(r => r.tag_name === state.tag);
     const isLegacy = selectedRelease ? !matchesExpectedPattern(selectedRelease.assets, version) : false;
 
+    // Grab the version and OS rows before either branch below wipes
+    // primaryContainer's innerHTML, since by the second render they live
+    // inside primaryContainer (moved there at the end of the previous
+    // call) and would otherwise be destroyed along with the rest of the
+    // old markup before we could reattach them.
+    const versionRow = document.getElementById('dl-version-row');
+    const osRow = document.getElementById('dl-os-row');
+
+    // Moves the (already-wired) version and OS rows into place, stacked in
+    // a small right-aligned column. A plain move, not a rebuild, so their
+    // select elements and change listeners survive the reattachment
+    // untouched. Called from both branches below so the title and both
+    // dropdowns stay visible even for a legacy release, which has no normal
+    // downloads/instructions to show. Prefers .dl-section-lead-row (sits
+    // below the title, alongside the lead paragraph) and falls back to
+    // .dl-section-title-row (the legacy template has no lead paragraph, so
+    // the controls pair with the title directly there instead).
+    function attachTitleControls() {
+      const targetRow = primaryContainer.querySelector('.dl-section-lead-row')
+        || primaryContainer.querySelector('.dl-section-title-row');
+      if (targetRow && versionRow && osRow) {
+        const controls = document.createElement('div');
+        controls.className = 'dl-title-controls';
+        controls.appendChild(versionRow);
+        controls.appendChild(osRow);
+        targetRow.appendChild(controls);
+      }
+    }
+
     if (isLegacy && selectedRelease) {
-      primaryContainer.innerHTML = renderLegacyView(selectedRelease.assets, selectedRelease.tag_name);
+      primaryContainer.innerHTML = renderDownloadSection({
+        title: 'App Installer',
+        id: 'app-installer',
+        sectionVariant: 'primary',
+        legacyHtml: renderLegacyView(selectedRelease.assets, selectedRelease.tag_name),
+      });
+      attachTitleControls();
       secondaryContainer.innerHTML = '';
       return;
     }
@@ -739,25 +790,48 @@
     appDownloads = enrichDownloadsWithR2Sizes(appDownloads, version, state.r2Sizes);
     serverDownloads = enrichDownloadsWithR2Sizes(serverDownloads, version, state.r2Sizes);
 
-    const matchesVariant = d => !d.variant || d.variant === state.variant;
+    // Both GPU/CPU variants show whenever the platform has both, instead of
+    // a manual picker gating which one is visible: the one matching the
+    // detected state.variant is the single "recommended" card, the other
+    // variant's equivalent lands in "alternates" alongside any secondary
+    // formats rather than being hidden away in "All Platforms & Formats".
+    const isDetectedVariant = d => !d.variant || d.variant === state.variant;
+    // Ranks alternates by how far they stray from the recommended card: a
+    // different format of the same (detected) variant is still hardware
+    // you actually have, so it ranks above the other variant entirely,
+    // and within that other variant its recommended format still ranks
+    // above its own secondary formats.
+    const altRank = d => isDetectedVariant(d) ? 0 : d.recommended ? 1 : 2;
+    const byAltRank = (a, b) => altRank(a) - altRank(b);
+
     const recApp = [], altApp = [], otherApp = [];
     appDownloads.forEach(d => {
-      if (d.os === state.os && d.arch === state.arch && matchesVariant(d)) {
-        (d.recommended ? recApp : altApp).push(d);
-      } else {
+      if (d.os !== state.os || d.arch !== state.arch) {
         otherApp.push(d);
+      } else if (d.recommended && isDetectedVariant(d)) {
+        recApp.push(d);
+      } else {
+        altApp.push(d);
       }
     });
-    const recServer = [], otherServer = [];
+    altApp.sort(byAltRank);
+
+    const recServer = [], altServer = [], otherServer = [];
     serverDownloads.forEach(d => {
-      if (d.os === state.os && d.arch === state.arch && matchesVariant(d)) recServer.push(d);
-      else otherServer.push(d);
+      if (d.os !== state.os || d.arch !== state.arch) {
+        otherServer.push(d);
+      } else if (isDetectedVariant(d)) {
+        recServer.push(d);
+      } else {
+        altServer.push(d);
+      }
     });
+    altServer.sort(byAltRank);
 
     const isUnavailablePlatform = state.os !== 'unknown' && recApp.length === 0 && altApp.length === 0 && recServer.length === 0;
     const osForInstructions = state.os === 'unknown' ? undefined : state.os;
-    const showVariantPicker = state.os !== 'unknown' && hasVariant(state.os, state.arch);
-    const variantForInstructions = showVariantPicker ? state.variant : undefined;
+    const osHasVariant = state.os !== 'unknown' && hasVariant(state.os, state.arch);
+    const variantForInstructions = osHasVariant ? state.variant : undefined;
 
     const appInstructions = (osForInstructions && !isUnavailablePlatform) ? getAppInstallInstructions(osForInstructions, state.arch, variantForInstructions, version) : [];
     const serverInstructions = (osForInstructions && !isUnavailablePlatform) ? getServerInstallInstructions(osForInstructions, state.arch, variantForInstructions, version) : [];
@@ -770,7 +844,7 @@
       icon: '',
       title: 'App Installer',
       id: 'app-installer',
-      leadHtml: '<strong>Recommended.</strong> Desktop application with camera preview, recording controls, and settings. The backend server is already bundled inside, meaning you don’t need to download it separately.',
+      leadHtml: '<strong>Recommended.</strong> Desktop application with camera preview, recording controls, and settings. If you are unsure which to choose, this is the one you want.',
       recommended: recApp,
       alternates: altApp,
       installInstructions: appInstructions,
@@ -785,32 +859,19 @@
       terminalInstallHtml: !isUnavailablePlatform ? renderTerminalInstallSection(state.os, state.arch, variantForInstructions, version) : '',
     });
 
-    // Grab the version row before the innerHTML wipe below, since by the
-    // second render it lives inside primaryContainer (moved there at the
-    // end of the previous call) and would otherwise be destroyed along
-    // with the rest of the old markup before we could reattach it.
-    const versionRow = document.getElementById('dl-version-row');
-
     primaryContainer.innerHTML = primaryHtml;
     wireLinkedIssues(primaryContainer, activeNotes);
     wireCopyButtons(primaryContainer);
-
-    // Move the (already-wired) version row into place next to the title.
-    // A plain move, not a rebuild, so its select element and change
-    // listener survive the reattachment untouched.
-    const titleRow = primaryContainer.querySelector('.dl-section-title-row');
-    if (titleRow && versionRow) titleRow.appendChild(versionRow);
+    attachTitleControls();
 
     let secondaryHtml = '<hr class="dl-section-divider">';
     secondaryHtml += renderDownloadSection({
       icon: '',
       title: 'Backend Server',
       id: 'backend-server',
-      subtitleHtml: '<strong>Advanced.</strong> Headless machines, remote capture rigs, API use.',
-      detailsLabel: 'When do I need this?',
-      detailsContentHtml: 'Just the camera backend server binary, no GUI. Useful for headless capture rigs, remote systems you connect to over a network, or building a custom client against the FreeMoCap API. <strong>You don’t need this if you downloaded the App Installer above.</strong>',
+      subtitleHtml: '<strong>Advanced.</strong> This is only necessary for headless machines, remote capture rigs, API use, etc. It is not necessary if you used the App Installer above.',
       recommended: recServer,
-      alternates: null,
+      alternates: altServer,
       installInstructions: serverInstructions,
       version,
       sectionVariant: 'secondary',
@@ -830,8 +891,7 @@
   }
 
   function render() {
-    renderSystemDetector();
-    renderVariantDetector();
+    renderOsSelect();
     renderVersionSelect();
     renderMainContent();
   }
@@ -862,23 +922,13 @@
 
   const gpu = detectGpu();
   state.variant = gpu.variant;
-  state.gpuDetected = gpu.detected;
 
-  document.querySelectorAll('#dl-os-pills .dl-pill').forEach(btn => {
-    btn.addEventListener('click', () => {
-      state.os = btn.dataset.os;
-      state.arch = btn.dataset.arch;
-      state.hasManualSystem = true;
-      render();
-    });
-  });
-
-  document.querySelectorAll('#dl-variant-pills .dl-pill').forEach(btn => {
-    btn.addEventListener('click', () => {
-      state.variant = btn.dataset.variant;
-      state.hasManualVariant = true;
-      render();
-    });
+  document.getElementById('dl-os-select').addEventListener('change', e => {
+    const [os, arch] = e.target.value.split(':');
+    state.os = os;
+    state.arch = arch;
+    state.hasManualSystem = true;
+    render();
   });
 
   document.getElementById('dl-version-select').addEventListener('change', e => {


### PR DESCRIPTION
## Summary
- Replace the OS/GPU pill pickers with dropdowns next to a restructured "App Installer" title, and always show both GPU/CPU variants (detected one flagged "Recommended") instead of hiding whichever isn't selected
- Extend the same variant-alternates treatment to the Backend Server section, and fix a bug where selecting a legacy-format release wiped the title and both dropdowns entirely
- Split "Install from terminal" so Backend Server gets its own toggle instead of App Installer's also serving Backend Server commands, and drop the collapsible wrapper on install instructions that are just one or two plain sentences with no code

## Test plan
- [ ] Load /download on each OS (Windows, macOS Apple Silicon, macOS Intel, Linux x64, Linux ARM64) and confirm the recommended card, alternates, and install instructions are correct
- [ ] Confirm the System OS and Version dropdowns both work and stay in sync with the shown downloads
- [ ] Confirm "Install from terminal" under App Installer only shows App Installer commands, and Backend Server's own "Install from terminal" only shows Backend Server commands
- [ ] Select an old/legacy-format release and confirm the title and both dropdowns stay visible
- [ ] Spot check on mobile width

🤖 Generated with [Claude Code](https://claude.com/claude-code)